### PR TITLE
Alpha: Substitutions, Initiative Turns, Injury Model, FanZone & Reputation v1

### DIFF
--- a/docs/substitution-system-report.md
+++ b/docs/substitution-system-report.md
@@ -1,0 +1,51 @@
+# Substitution System Implementation Report
+
+## Overview
+Added a tactical-match substitution flow with in-match lineup replacement for the player-controlled side.
+
+## What changed
+- `scripts/match/tactical/match_controller.gd`
+  - Added substitution state tracking:
+    - `home_lineup`, `away_lineup`
+    - `home_substitutions_used`, `away_substitutions_used`
+    - `MAX_SUBSTITUTIONS_PER_SIDE = 3`
+  - Added runtime roster helpers to identify bench candidates from active squad data.
+  - Added player-facing APIs used by UI:
+    - `get_substitution_candidates_for_player_team()`
+    - `get_remaining_substitutions()`
+    - `can_player_substitute()`
+    - `perform_substitution()`
+  - Added substitution execution logic in `_apply_substitution(...)` to:
+    - Replace the outgoing on-field `PlayerUnit` instance
+    - Instantiate the incoming player
+    - Update lineup arrays, unit arrays, and initiative order references
+    - Transfer ball possession if outgoing had possession
+    - Emit `substitution_executed` and record a `substitution` match event
+
+- `scripts/match/tactical/tactical_ui_controller.gd`
+  - Added Substitute button binding and handler:
+    - New `@onready` binding for `SubstituteBtn`
+    - New `_on_substitute_btn_pressed()` handler
+    - Substitution button disables unless valid
+    - Button label updates with remaining subs
+
+- `scenes/match/tactical/tactical_match.tscn`
+  - Added `SubstituteBtn` under the action button grid
+  - Connected signal to `_on_substitute_btn_pressed()`
+
+## Notes / current scope
+- The current substitution selection is automated:
+  - **Outgoing:** lowest-rated non-player unit (falls back to any unit if needed)
+  - **Incoming:** highest-rated available bench player
+- This keeps implementation lightweight while providing full gameplay capability.
+- Substitution is only enabled when:
+  - It is the player turn
+  - Player turn actions are active
+  - Current player unit is at full AP
+  - Remaining substitution budget exists
+  - Bench candidates are available
+
+## Team-facing follow-up suggestions
+- Add explicit UI for selecting outgoing and incoming players.
+- Add support for opponent-side substitutions and scenario rules (time windows/injury flags).
+- Add substitution animation/feedback when swap occurs.

--- a/docs/todo-season-awards.md
+++ b/docs/todo-season-awards.md
@@ -23,7 +23,7 @@ Goal: track match stats across the season to award titles like Top Goal Scorer a
 
 ## Match Recording
 - [x] Extend `MatchData` result payload to include scorer/assist events for both teams.
-- [ ] Tactical matches: record goal events for all scorers (not just player) so season totals can be updated.
+- [x] Tactical matches: record goal events for all scorers (not just player) so season totals can be updated.
 - [x] Simulated matches (`MatchSimulator`) generate per-team and per-player goal/assist distributions:
   - [x] Use team roster from `TeamData.players[]`
   - [x] Weight by position (ST > WNG > CAM > CM for goals)
@@ -95,5 +95,5 @@ This feature should be implemented **before** NPC Persona Generator as it:
 - UI panel created for viewing awards
 
 ### Remaining Work
-- Tactical match goal attribution (currently only simulated matches track stats)
+- ~~Tactical match goal attribution (currently only simulated matches track stats)~~
 - Unit tests

--- a/docs/unit-level-initiative-order-report.md
+++ b/docs/unit-level-initiative-order-report.md
@@ -1,0 +1,45 @@
+# Unit-Level Initiative Order Report
+
+## Summary
+We implemented a per-unit initiative order for tactical match turns in `MatchController` so the next actor is chosen by unit initiative each match minute, not by fixed Team → Opponent sequencing.
+
+## What changed
+- Added initiative queue state in `scripts/match/tactical/match_controller.gd`:
+  - `initiative_order: Array[PlayerUnit]`
+  - `initiative_cursor: int`
+  - `is_player_turn_active: bool`
+- Replaced fixed turn-phase flow (`PLAYER -> TEAM -> OPPONENT`) with queue-driven flow:
+  - Start-of-turn setup resets all units.
+  - Build sorted initiative order from units.
+  - Process each actor in order:
+    - Player actor → `TurnPhase.PLAYER` and input waits.
+    - AI actor → `TurnPhase.TEAM` or `TurnPhase.OPPONENT` and performs up to 3 AI actions.
+  - Turn advances when initiative queue is exhausted.
+- Added initiative scoring helpers:
+  - `_build_initiative_order`
+  - `_calculate_unit_initiative`
+  - `_sort_initiative_entries`
+  - `_get_next_initiative_actor`
+- Added AI turn runner:
+  - `_process_ai_unit_turn`
+- Kept existing half-time and minute progression, score flow, and event recording intact.
+
+## Initiative formula
+Current implementation currently uses:
+- `SPD * 2`
+- + player control bonus (+2)
+- + goalkeeper penalty (-3)
+- + random variance (`randi_range(0, 12)`)
+
+This keeps turns responsive and still lets speed-driven differences matter without fully removing momentum from stat progression.
+
+## Impact on gameplay
+- No longer a rigid “all teammates, then all opponents” phase lock.
+- Faster perceived back-and-forth potential: stronger players can act earlier regardless of team.
+- Player still has explicit control of when to end their initiative turn.
+- Existing action economy (AP) and 45-turn minute pacing are preserved.
+
+## Operational notes for team
+- If we want this to be deterministic for replay/balancing analysis, remove initiative jitter.
+- If we want deeper fairness, tie-breaker can be expanded to include role/fitness/fatigue context.
+- Next likely iteration: expose initiative order in UI for readability in commentary/log panel.

--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,10 @@ window/size/viewport_height=1080
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
+[debug]
+
+fanzone_v2_enabled=false
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/gut/plugin.cfg")

--- a/project.godot
+++ b/project.godot
@@ -33,6 +33,7 @@ DesktopManager="*res://scripts/desktop/desktop_manager.gd"
 SeasonManager="*res://scripts/season/season_manager.gd"
 PersonaManager="*res://scripts/persona/persona_manager.gd"
 NpcRegistry="*res://scripts/core/npc_registry.gd"
+SocialFeedManager="*res://scripts/social/social_feed_manager.gd"
 
 [display]
 

--- a/scenes/dashboard/components/player_mini_card.tscn
+++ b/scenes/dashboard/components/player_mini_card.tscn
@@ -55,6 +55,22 @@ theme_override_colors/font_color = Color(1, 0.84, 0, 1)
 theme_override_font_sizes/font_size = 14
 text = "OVR 67"
 
+[node name="ReputationRow" type="HBoxContainer" parent="MarginContainer/HBoxContainer/InfoContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ReputationLabel" type="Label" parent="MarginContainer/HBoxContainer/InfoContainer/ReputationRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.85, 1, 1)
+theme_override_font_sizes/font_size = 13
+text = "REP 10"
+
+[node name="ReputationTierLabel" type="Label" parent="MarginContainer/HBoxContainer/InfoContainer/ReputationRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.75, 0.8, 1)
+theme_override_font_sizes/font_size = 13
+text = "Unknown"
+
 [node name="FormRow" type="HBoxContainer" parent="MarginContainer/HBoxContainer/InfoContainer"]
 layout_mode = 2
 theme_override_constants/separation = 8

--- a/scenes/dashboard/panels/panel_social.tscn
+++ b/scenes/dashboard/panels/panel_social.tscn
@@ -83,3 +83,13 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 16
+
+[node name="ThreadView" type="VBoxContainer" parent="ContentContainer/MarginContainer/VBoxContainer/ContentArea"]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 12

--- a/scenes/dashboard/panels/panel_social_v2.tscn
+++ b/scenes/dashboard/panels/panel_social_v2.tscn
@@ -1,0 +1,95 @@
+[gd_scene load_steps=2 format=3 uid="uid://panel_social_v2_001"]
+
+[ext_resource type="Script" path="res://scripts/dashboard/panels/panel_social_v2.gd" id="1_script"]
+
+[node name="PanelSocialV2" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_script")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.85)
+
+[node name="ContentContainer" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 48.0
+offset_top = 48.0
+offset_right = -48.0
+offset_bottom = -48.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="ContentContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 32
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 32
+theme_override_constants/margin_bottom = 24
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ContentContainer/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 16
+
+[node name="Header" type="HBoxContainer" parent="ContentContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="ContentContainer/MarginContainer/VBoxContainer/Header"]
+custom_minimum_size = Vector2(80, 36)
+layout_mode = 2
+text = "< Back"
+
+[node name="TitleLabel" type="Label" parent="ContentContainer/MarginContainer/VBoxContainer/Header"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
+theme_override_font_sizes/font_size = 24
+text = "FanZone"
+horizontal_alignment = 1
+
+[node name="Spacer" type="Control" parent="ContentContainer/MarginContainer/VBoxContainer/Header"]
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+
+[node name="ContentArea" type="Control" parent="ContentContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="MainContent" type="VBoxContainer" parent="ContentContainer/MarginContainer/VBoxContainer/ContentArea"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ScrollContainer" type="ScrollContainer" parent="ContentContainer/MarginContainer/VBoxContainer/ContentArea/MainContent"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="FeedContainer" type="VBoxContainer" parent="ContentContainer/MarginContainer/VBoxContainer/ContentArea/MainContent/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 16
+
+[node name="ThreadView" type="VBoxContainer" parent="ContentContainer/MarginContainer/VBoxContainer/ContentArea"]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 12

--- a/scenes/desktop/desktop_shell.tscn
+++ b/scenes/desktop/desktop_shell.tscn
@@ -40,7 +40,7 @@ anchor_bottom = 1.0
 offset_bottom = -40.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 1
+mouse_filter = 2
 
 [node name="Taskbar" type="PanelContainer" parent="."]
 layout_mode = 1

--- a/scenes/match/post_match.tscn
+++ b/scenes/match/post_match.tscn
@@ -199,6 +199,21 @@ theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
 text = "+100 XP"
 horizontal_alignment = 1
 
+[node name="ReputationLabel" type="Label" parent="MainContainer/RewardsSection"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+theme_override_colors/font_color = Color(0.55, 0.88, 1, 1)
+text = "Reputation: +0 -> 10 (Unknown)"
+horizontal_alignment = 1
+
+[node name="ReputationBreakdown" type="Label" parent="MainContainer/RewardsSection"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 13
+theme_override_colors/font_color = Color(0.68, 0.74, 0.82, 1)
+text = "No reputation changes."
+horizontal_alignment = 1
+autowrap_mode = 2
+
 [node name="MilestonesContainer" type="VBoxContainer" parent="MainContainer/RewardsSection"]
 layout_mode = 2
 theme_override_constants/separation = 5

--- a/scenes/match/tactical/tactical_match.tscn
+++ b/scenes/match/tactical/tactical_match.tscn
@@ -166,6 +166,11 @@ custom_minimum_size = Vector2(120, 35)
 layout_mode = 2
 text = "End Turn"
 
+[node name="SubstituteBtn" type="Button" parent="UI/ActionPanel/VBoxContainer/ButtonGrid"]
+custom_minimum_size = Vector2(120, 35)
+layout_mode = 2
+text = "Substitute"
+
 [node name="InfoPanel" type="PanelContainer" parent="UI"]
 anchors_preset = 1
 anchor_left = 1.0
@@ -204,3 +209,4 @@ script = ExtResource("2_ui_controller")
 [connection signal="pressed" from="UI/ActionPanel/VBoxContainer/ButtonGrid/DribbleBtn" to="UI/UIController" method="_on_dribble_btn_pressed"]
 [connection signal="pressed" from="UI/ActionPanel/VBoxContainer/ButtonGrid/TackleBtn" to="UI/UIController" method="_on_tackle_btn_pressed"]
 [connection signal="pressed" from="UI/ActionPanel/VBoxContainer/ButtonGrid/EndTurnBtn" to="UI/UIController" method="_on_end_turn_btn_pressed"]
+[connection signal="pressed" from="UI/ActionPanel/VBoxContainer/ButtonGrid/SubstituteBtn" to="UI/UIController" method="_on_substitute_btn_pressed"]

--- a/scripts/career/career_manager.gd
+++ b/scripts/career/career_manager.gd
@@ -130,9 +130,16 @@ func _update_reputation(result: Dictionary) -> void:
 func _add_reputation(amount: int) -> void:
 	var old_rep = reputation
 	reputation = clampi(reputation + amount, 0, 100)
-	
+
 	if reputation != old_rep:
 		reputation_changed.emit(reputation)
+
+
+func apply_social_reputation_delta(delta: int, reason: String) -> void:
+	if delta == 0:
+		return
+	_add_reputation(delta)
+	print("[CareerManager] Social reputation delta %d (%s)" % [delta, reason])
 
 
 func _check_scout_interest(result: Dictionary) -> void:

--- a/scripts/career/career_manager.gd
+++ b/scripts/career/career_manager.gd
@@ -3,9 +3,48 @@ extends Node
 ## Tracks the player's journey from high school to professional career
 
 signal reputation_changed(new_reputation: int)
+signal reputation_delta_applied(delta: int, new_value: int, source: String, details: Dictionary)
+signal reputation_tier_changed(old_tier: String, new_tier: String)
+signal fan_popularity_changed(new_total: int, delta: int, outcome: String)
 signal milestone_reached(milestone: String)
 signal scout_interest(scout_data: Dictionary)
 signal contract_offer_received(offer: Dictionary)
+
+const REPUTATION_MIN := 0
+const REPUTATION_MAX := 100
+const MILESTONE_REPUTATION_BONUS := 5
+const SOCIAL_DAILY_CAP := 4
+const MAX_REPUTATION_EVENTS := 100
+
+const REPUTATION_TIERS: Array[Dictionary] = [
+	{"id": "unknown", "name": "Unknown", "min": 0, "max": 14},
+	{"id": "prospect", "name": "Prospect", "min": 15, "max": 29},
+	{"id": "rising_star", "name": "Rising Star", "min": 30, "max": 49},
+	{"id": "noted_talent", "name": "Noted Talent", "min": 50, "max": 69},
+	{"id": "national_buzz", "name": "National Buzz", "min": 70, "max": 84},
+	{"id": "wonderkid", "name": "Wonderkid", "min": 85, "max": 100}
+]
+
+const SCOUT_CHANCE_TIER_MULTIPLIER := {
+	"unknown": 0.80,
+	"prospect": 0.95,
+	"rising_star": 1.05,
+	"noted_talent": 1.15,
+	"national_buzz": 1.25,
+	"wonderkid": 1.35
+}
+
+const CONTRACT_VALUE_TIER_MULTIPLIER := {
+	"unknown": 0.90,
+	"prospect": 1.00,
+	"rising_star": 1.08,
+	"noted_talent": 1.18,
+	"national_buzz": 1.30,
+	"wonderkid": 1.45
+}
+
+const SOCIAL_DIMINISHING_FACTORS := [1.0, 0.5, 0.25, 0.1]
+const SOCIAL_ELIGIBLE_LIKE_POST_TYPES := ["news_article", "match_summary", "milestone", "season_update"]
 
 # Career statistics
 var match_history: Array[Dictionary] = []
@@ -24,6 +63,11 @@ var reputation: int = 10  # Start as unknown high schooler
 var scout_attention: Dictionary = {}  # team_id -> interest level
 var media_coverage: int = 0
 var fan_popularity: int = 0
+var reputation_event_log: Array[Dictionary] = []
+var last_match_reputation_report: Dictionary = {}
+var social_rep_day_key: String = ""
+var social_rep_awarded_today: int = 0
+var social_rep_actions_today: int = 0
 
 # Milestones tracking
 var completed_milestones: Array[String] = []
@@ -57,106 +101,292 @@ func _ready() -> void:
 	print("[CareerManager] Initialized")
 
 
+func reset_for_new_career() -> void:
+	match_history.clear()
+	career_stats = {
+		"matches_played": 0,
+		"goals": 0,
+		"assists": 0,
+		"clean_sheets": 0,
+		"man_of_match_awards": 0,
+		"trophies": [],
+		"current_season": 1
+	}
+	completed_milestones.clear()
+	rivals.clear()
+	rival_encounters.clear()
+	scout_attention.clear()
+
+	reputation = 10
+	media_coverage = 0
+	fan_popularity = 0
+	reputation_event_log.clear()
+	last_match_reputation_report = {}
+	social_rep_day_key = _get_current_day_key()
+	social_rep_awarded_today = 0
+	social_rep_actions_today = 0
+
+
 func record_match_result(result: Dictionary) -> void:
 	match_history.append(result)
-	
+
 	# Update career stats
-	career_stats.matches_played += 1
-	career_stats.goals += result.get("goals", 0)
-	career_stats.assists += result.get("assists", 0)
-	
+	career_stats["matches_played"] = int(career_stats.get("matches_played", 0)) + 1
+	career_stats["goals"] = int(career_stats.get("goals", 0)) + int(result.get("goals", 0))
+	career_stats["assists"] = int(career_stats.get("assists", 0)) + int(result.get("assists", 0))
+
 	if result.get("clean_sheet", false):
-		career_stats.clean_sheets += 1
-	
+		career_stats["clean_sheets"] = int(career_stats.get("clean_sheets", 0)) + 1
+
 	if result.get("man_of_match", false):
-		career_stats.man_of_match_awards += 1
-	
-	# Check for milestones
-	_check_milestones(result)
-	
-	# Update reputation
-	_update_reputation(result)
-	
+		career_stats["man_of_match_awards"] = int(career_stats.get("man_of_match_awards", 0)) + 1
+
+	var breakdown: Array[Dictionary] = []
+	var match_delta = _calculate_match_reputation_delta(result, breakdown)
+	var rep_before = reputation
+	_apply_reputation_delta(match_delta, "match_performance", {"breakdown": breakdown, "match_id": result.get("match_id", "")})
+
+	var milestone_ids = _check_milestones(result)
+	for milestone_id in milestone_ids:
+		if award_milestone(milestone_id):
+			breakdown.append({"source": "milestone", "delta": MILESTONE_REPUTATION_BONUS, "milestone_id": milestone_id})
+
+	var total_delta = reputation - rep_before
+	var tier = get_reputation_tier()
+	last_match_reputation_report = {
+		"reputation_before": rep_before,
+		"reputation_after": reputation,
+		"reputation_delta": total_delta,
+		"reputation_tier": tier.get("name", "Unknown"),
+		"reputation_tier_id": tier.get("id", "unknown"),
+		"reputation_breakdown": breakdown.duplicate(true),
+		"milestones_awarded": milestone_ids.duplicate(),
+		"match_delta": match_delta
+	}
+
+	# Attach report to the payload consumed by UI screens.
+	result["reputation_before"] = rep_before
+	result["reputation_after"] = reputation
+	result["reputation_delta"] = total_delta
+	result["reputation_tier"] = tier.get("name", "Unknown")
+	result["reputation_breakdown"] = breakdown.duplicate(true)
+
+	# Keep flavor metrics in sync with current profile.
+	media_coverage = clampi(reputation, REPUTATION_MIN, REPUTATION_MAX)
+	_update_fan_popularity_from_match(result)
+
 	# Check for scout interest
 	_check_scout_interest(result)
 
 
-func _check_milestones(result: Dictionary) -> void:
-	if "first_goal" not in completed_milestones and career_stats.goals > 0:
-		_complete_milestone("first_goal")
-	
-	if "first_assist" not in completed_milestones and career_stats.assists > 0:
-		_complete_milestone("first_assist")
-	
-	if "first_motm" not in completed_milestones and career_stats.man_of_match_awards > 0:
-		_complete_milestone("first_motm")
-	
-	if "ten_goals" not in completed_milestones and career_stats.goals >= 10:
-		_complete_milestone("ten_goals")
+func _check_milestones(_result: Dictionary) -> Array[String]:
+	var newly_completed: Array[String] = []
+
+	if "first_goal" not in completed_milestones and int(career_stats.get("goals", 0)) > 0:
+		newly_completed.append("first_goal")
+
+	if "first_assist" not in completed_milestones and int(career_stats.get("assists", 0)) > 0:
+		newly_completed.append("first_assist")
+
+	if "first_motm" not in completed_milestones and int(career_stats.get("man_of_match_awards", 0)) > 0:
+		newly_completed.append("first_motm")
+
+	if "ten_goals" not in completed_milestones and int(career_stats.get("goals", 0)) >= 10:
+		newly_completed.append("ten_goals")
+
+	return newly_completed
 
 
-func _complete_milestone(milestone_id: String) -> void:
+func _complete_milestone(milestone_id: String) -> bool:
 	if milestone_id in MILESTONES and milestone_id not in completed_milestones:
 		completed_milestones.append(milestone_id)
 		print("[CareerManager] Milestone reached: %s" % MILESTONES[milestone_id].name)
 		milestone_reached.emit(milestone_id)
-		
-		# Milestones boost reputation
-		_add_reputation(5)
+		return true
+	return false
 
 
-func _update_reputation(result: Dictionary) -> void:
-	var rep_change = 0
-	
-	# Performance-based reputation gains
-	rep_change += result.get("goals", 0) * 2
-	rep_change += result.get("assists", 0) * 1
-	
-	if result.get("man_of_match", false):
-		rep_change += 5
-	
-	if result.get("won", false):
-		rep_change += 1
-	elif result.get("lost", false):
-		rep_change -= 1
-	
-	# Scale by match importance
-	var importance_multiplier = result.get("importance", 1.0)
-	rep_change = roundi(rep_change * importance_multiplier)
-	
-	_add_reputation(rep_change)
+func award_milestone(milestone_id: String, details: Dictionary = {}) -> bool:
+	if not _complete_milestone(milestone_id):
+		return false
+	var rep_details = details.duplicate(true)
+	rep_details["milestone_id"] = milestone_id
+	_apply_reputation_delta(MILESTONE_REPUTATION_BONUS, "milestone", rep_details)
+	return true
 
 
-func _add_reputation(amount: int) -> void:
+func _calculate_match_reputation_delta(result: Dictionary, breakdown: Array[Dictionary]) -> int:
+	var raw_delta = 0
+
+	var goals = int(result.get("goals", 0))
+	if goals > 0:
+		var goals_delta = goals * 2
+		raw_delta += goals_delta
+		breakdown.append({"source": "goals", "delta": goals_delta})
+
+	var assists = int(result.get("assists", 0))
+	if assists > 0:
+		raw_delta += assists
+		breakdown.append({"source": "assists", "delta": assists})
+
+	if bool(result.get("won", false)):
+		raw_delta += 2
+		breakdown.append({"source": "win", "delta": 2})
+	elif bool(result.get("lost", false)):
+		raw_delta -= 2
+		breakdown.append({"source": "loss", "delta": -2})
+
+	if bool(result.get("man_of_match", false)):
+		raw_delta += 4
+		breakdown.append({"source": "man_of_match", "delta": 4})
+
+	if bool(result.get("clean_sheet", false)):
+		raw_delta += 1
+		breakdown.append({"source": "clean_sheet", "delta": 1})
+
+	var yellow_cards = mini(int(result.get("yellow_cards", 0)), 2)
+	if yellow_cards > 0:
+		var yellow_delta = -yellow_cards
+		raw_delta += yellow_delta
+		breakdown.append({"source": "yellow_cards", "delta": yellow_delta})
+
+	if bool(result.get("red_card", false)):
+		raw_delta -= 4
+		breakdown.append({"source": "red_card", "delta": -4})
+
+	var rating = float(result.get("rating", 6.0))
+	if rating >= 8.5:
+		raw_delta += 2
+		breakdown.append({"source": "rating", "delta": 2, "rating": rating})
+	elif rating >= 7.0:
+		raw_delta += 1
+		breakdown.append({"source": "rating", "delta": 1, "rating": rating})
+	elif rating < 5.5:
+		raw_delta -= 2
+		breakdown.append({"source": "rating", "delta": -2, "rating": rating})
+	elif rating < 6.5:
+		raw_delta -= 1
+		breakdown.append({"source": "rating", "delta": -1, "rating": rating})
+
+	var importance = clampf(float(result.get("importance", 1.0)), 0.5, 3.0)
+	var scaled_delta = roundi(float(raw_delta) * importance)
+	breakdown.append({"source": "importance_scale", "delta": scaled_delta - raw_delta, "importance": importance})
+	return scaled_delta
+
+
+func _apply_reputation_delta(amount: int, source: String, details: Dictionary = {}) -> Dictionary:
 	var old_rep = reputation
-	reputation = clampi(reputation + amount, 0, 100)
+	reputation = clampi(reputation + amount, REPUTATION_MIN, REPUTATION_MAX)
+	var applied_delta = reputation - old_rep
+	var old_tier_id = get_reputation_tier(old_rep).get("id", "unknown")
+	var new_tier = get_reputation_tier(reputation)
+	var new_tier_id = new_tier.get("id", "unknown")
 
-	if reputation != old_rep:
+	var entry = {
+		"timestamp": Time.get_unix_time_from_system(),
+		"source": source,
+		"requested_delta": amount,
+		"applied_delta": applied_delta,
+		"before": old_rep,
+		"after": reputation,
+		"details": details.duplicate(true)
+	}
+	reputation_event_log.append(entry)
+	if reputation_event_log.size() > MAX_REPUTATION_EVENTS:
+		reputation_event_log.pop_front()
+
+	if applied_delta != 0:
 		reputation_changed.emit(reputation)
+		reputation_delta_applied.emit(applied_delta, reputation, source, details)
+		if old_tier_id != new_tier_id:
+			reputation_tier_changed.emit(old_tier_id, new_tier_id)
+
+	return entry
+
+
+func apply_social_reputation(action_type: String, payload: Dictionary = {}) -> Dictionary:
+	_sync_social_day()
+
+	var base_delta = 0
+	match action_type:
+		"player_post":
+			base_delta = 2
+		"player_reply":
+			base_delta = 1
+		"like":
+			var post_type = str(payload.get("post_type", ""))
+			var liked = bool(payload.get("liked", false))
+			if liked and post_type in SOCIAL_ELIGIBLE_LIKE_POST_TYPES:
+				base_delta = 1
+		_:
+			base_delta = int(payload.get("base_delta", 0))
+
+	if base_delta <= 0:
+		return {"requested_delta": base_delta, "applied_delta": 0, "reason": "ineligible"}
+
+	var action_idx = social_rep_actions_today
+	social_rep_actions_today += 1
+	var factor = float(SOCIAL_DIMINISHING_FACTORS[min(action_idx, SOCIAL_DIMINISHING_FACTORS.size() - 1)])
+	var diminished_delta = int(round(float(base_delta) * factor))
+	if diminished_delta <= 0:
+		return {"requested_delta": base_delta, "applied_delta": 0, "reason": "diminished_to_zero", "factor": factor}
+
+	var remaining = maxi(SOCIAL_DAILY_CAP - social_rep_awarded_today, 0)
+	var applied = mini(diminished_delta, remaining)
+	if applied <= 0:
+		return {"requested_delta": base_delta, "applied_delta": 0, "reason": "daily_cap_reached", "factor": factor}
+
+	social_rep_awarded_today += applied
+	_apply_reputation_delta(applied, "social_%s" % action_type, {
+		"action_type": action_type,
+		"factor": factor,
+		"payload": payload.duplicate(true),
+		"remaining_after": maxi(SOCIAL_DAILY_CAP - social_rep_awarded_today, 0)
+	})
+
+	return {
+		"requested_delta": base_delta,
+		"diminished_delta": diminished_delta,
+		"applied_delta": applied,
+		"factor": factor,
+		"daily_awarded": social_rep_awarded_today,
+		"daily_cap": SOCIAL_DAILY_CAP
+	}
 
 
 func apply_social_reputation_delta(delta: int, reason: String) -> void:
-	if delta == 0:
+	# Compatibility shim for older callers/tests.
+	if delta <= 0:
 		return
-	_add_reputation(delta)
-	print("[CareerManager] Social reputation delta %d (%s)" % [delta, reason])
+	_sync_social_day()
+	var remaining = maxi(SOCIAL_DAILY_CAP - social_rep_awarded_today, 0)
+	var applied = mini(delta, remaining)
+	if applied <= 0:
+		return
+	social_rep_awarded_today += applied
+	social_rep_actions_today += 1
+	_apply_reputation_delta(applied, "social_legacy", {"reason": reason, "requested_delta": delta})
+	print("[CareerManager] Social reputation delta %d (%s)" % [applied, reason])
 
 
 func _check_scout_interest(result: Dictionary) -> void:
 	# Only scouts watch if reputation is high enough
 	if reputation < 20:
 		return
-	
-	# Chance of scout attendance based on reputation and match importance
-	var scout_chance = (reputation / 100.0) * result.get("importance", 1.0)
-	
+
+	# Chance of scout attendance based on reputation, match importance, and tier.
+	var tier_id = str(get_reputation_tier().get("id", "unknown"))
+	var tier_multiplier = float(SCOUT_CHANCE_TIER_MULTIPLIER.get(tier_id, 1.0))
+	var scout_chance = (float(reputation) / 100.0) * float(result.get("importance", 1.0)) * tier_multiplier
+	scout_chance = clampf(scout_chance, 0.0, 0.98)
+
 	if randf() < scout_chance:
 		var scout = _generate_scout()
-		
+
 		# Scout evaluates performance
 		var impression = _calculate_scout_impression(result)
-		scout_attention[scout.team_id] = scout_attention.get(scout.team_id, 0) + impression
-		
+		scout_attention[scout.team_id] = int(scout_attention.get(scout.team_id, 0)) + impression
+
 		scout_interest.emit(scout)
 
 
@@ -165,7 +395,7 @@ func _generate_scout() -> Dictionary:
 	var phase = GameManager.current_career_phase
 	var teams = _get_scouting_teams(phase)
 	var team = teams[randi() % teams.size()]
-	
+
 	return {
 		"team_id": team.id,
 		"team_name": team.name,
@@ -203,41 +433,47 @@ func _generate_scout_name() -> String:
 
 func _calculate_scout_impression(result: Dictionary) -> int:
 	var impression = 0
-	impression += result.get("goals", 0) * 10
-	impression += result.get("assists", 0) * 7
-	impression += result.get("successful_passes", 0) / 5
-	impression += result.get("successful_tackles", 0) * 3
-	
+	impression += int(result.get("goals", 0)) * 10
+	impression += int(result.get("assists", 0)) * 7
+	impression += int(result.get("successful_passes", 0)) / 5
+	impression += int(result.get("successful_tackles", 0)) * 3
+
 	if result.get("man_of_match", false):
 		impression += 20
-	
+
 	return impression
 
 
 func generate_contract_offer(team_id: String) -> Dictionary:
-	var interest = scout_attention.get(team_id, 0)
-	
+	var interest = int(scout_attention.get(team_id, 0))
+
 	if interest < 30:
 		return {}  # Not enough interest
-	
+
+	var tier = get_reputation_tier()
+	var tier_id = str(tier.get("id", "unknown"))
 	var offer = {
 		"team_id": team_id,
-		"salary": _calculate_offer_salary(interest),
+		"team_name": _team_name_from_scouting_pool(team_id),
+		"salary": _calculate_offer_salary(interest, tier_id),
 		"duration_years": randi_range(1, 3),
-		"signing_bonus": _calculate_signing_bonus(interest),
-		"squad_role": _determine_squad_role(interest)
+		"signing_bonus": _calculate_signing_bonus(interest, tier_id),
+		"squad_role": _determine_squad_role(interest),
+		"reputation_tier": tier.get("name", "Unknown")
 	}
-	
+
 	contract_offer_received.emit(offer)
 	return offer
 
 
-func _calculate_offer_salary(interest: int) -> int:
-	return roundi(interest * 1000 * (1.0 + randf() * 0.3))
+func _calculate_offer_salary(interest: int, tier_id: String) -> int:
+	var tier_multiplier = float(CONTRACT_VALUE_TIER_MULTIPLIER.get(tier_id, 1.0))
+	return roundi(interest * 1000 * tier_multiplier * (1.0 + randf() * 0.3))
 
 
-func _calculate_signing_bonus(interest: int) -> int:
-	return roundi(interest * 500 * randf())
+func _calculate_signing_bonus(interest: int, tier_id: String) -> int:
+	var tier_multiplier = float(CONTRACT_VALUE_TIER_MULTIPLIER.get(tier_id, 1.0))
+	return roundi(interest * 500 * tier_multiplier * randf())
 
 
 func _determine_squad_role(interest: int) -> String:
@@ -253,10 +489,41 @@ func get_career_summary() -> Dictionary:
 	return {
 		"phase": GameManager.get_career_phase_name(),
 		"reputation": reputation,
+		"reputation_tier": get_reputation_tier().get("name", "Unknown"),
 		"stats": career_stats,
 		"milestones": completed_milestones.size(),
 		"total_milestones": MILESTONES.size()
 	}
+
+
+func get_reputation_tier(score: int = -1) -> Dictionary:
+	var lookup = score
+	if lookup < 0:
+		lookup = reputation
+	for tier in REPUTATION_TIERS:
+		if lookup >= int(tier.get("min", 0)) and lookup <= int(tier.get("max", REPUTATION_MAX)):
+			return tier
+	return REPUTATION_TIERS[0]
+
+
+func get_reputation_summary() -> Dictionary:
+	var tier = get_reputation_tier()
+	_sync_social_day()
+	return {
+		"score": reputation,
+		"tier_id": tier.get("id", "unknown"),
+		"tier_name": tier.get("name", "Unknown"),
+		"media_coverage": media_coverage,
+		"fan_popularity": fan_popularity,
+		"daily_social_awarded": social_rep_awarded_today,
+		"daily_social_cap": SOCIAL_DAILY_CAP,
+		"daily_social_actions": social_rep_actions_today,
+		"event_log_size": reputation_event_log.size()
+	}
+
+
+func get_last_match_reputation_report() -> Dictionary:
+	return last_match_reputation_report.duplicate(true)
 
 
 func add_rival(rival_data: Dictionary) -> void:
@@ -277,15 +544,15 @@ func record_season_award(award_type: String, stat_value: int = 0) -> void:
 	# award_type: "golden_boot", "playmaker_award", or "golden_glove"
 
 	# Complete the corresponding milestone
-	_complete_milestone(award_type)
+	award_milestone(award_type, {"from_award": true})
 
 	# Awards give extra reputation boost (on top of milestone bonus)
-	var bonus_rep = 10 + (stat_value / 2)  # Bigger bonus for higher stats
-	_add_reputation(bonus_rep)
+	var bonus_rep = 10 + int(stat_value / 2)  # Bigger bonus for higher stats
+	_apply_reputation_delta(bonus_rep, "season_award", {"award_type": award_type, "stat_value": stat_value})
 
 	# Increase scout attention significantly
 	for team_id in scout_attention:
-		scout_attention[team_id] += 15
+		scout_attention[team_id] = int(scout_attention[team_id]) + 15
 
 	# If no scouts watching yet, generate interest from some teams
 	if scout_attention.is_empty() and reputation >= 15:
@@ -299,7 +566,68 @@ func record_season_award(award_type: String, stat_value: int = 0) -> void:
 	career_stats["awards"].append({
 		"type": award_type,
 		"value": stat_value,
-		"season": career_stats.current_season
+		"season": int(career_stats.get("current_season", 1))
 	})
 
 	print("[CareerManager] Player won %s with %d" % [award_type, stat_value])
+
+
+func _update_fan_popularity_from_match(result: Dictionary) -> void:
+	var outcome = "draw"
+	var base_change = 0.0
+	if bool(result.get("won", false)):
+		outcome = "win"
+		base_change = 3.0 + (float(reputation) * 0.3)
+	elif bool(result.get("lost", false)):
+		outcome = "loss"
+		base_change = -(1.0 + (float(reputation) * 0.05))
+	else:
+		result["followers_delta"] = 0
+		result["followers_total"] = fan_popularity
+		return
+
+	var importance = clampf(float(result.get("importance", 1.0)), 0.5, 3.0)
+	var raw_change = base_change * importance
+	var proposed_delta = int(raw_change) if raw_change >= 0.0 else -int(abs(raw_change))
+	var old_followers = fan_popularity
+	fan_popularity = maxi(fan_popularity + proposed_delta, 0)
+	var applied_delta = fan_popularity - old_followers
+
+	result["followers_delta"] = applied_delta
+	result["followers_total"] = fan_popularity
+
+	if applied_delta != 0:
+		fan_popularity_changed.emit(fan_popularity, applied_delta, outcome)
+
+
+func accept_contract(offer: Dictionary) -> void:
+	# Stubbed acceptance path for existing email UI hooks.
+	if offer.is_empty():
+		return
+	award_milestone("first_pro_contract", {"from_contract": true})
+	_apply_reputation_delta(3, "contract_accept", {"team_id": offer.get("team_id", "")})
+
+
+func _sync_social_day() -> void:
+	var day_key = _get_current_day_key()
+	if social_rep_day_key == day_key:
+		return
+	social_rep_day_key = day_key
+	social_rep_awarded_today = 0
+	social_rep_actions_today = 0
+
+
+func _get_current_day_key() -> String:
+	if DesktopManager and DesktopManager.game_date:
+		var d = DesktopManager.game_date
+		return "%04d-%02d-%02d" % [int(d.get("year", 2024)), int(d.get("month", 1)), int(d.get("day", 1))]
+	var date = Time.get_date_dict_from_system()
+	return "%04d-%02d-%02d" % [int(date.get("year", 2024)), int(date.get("month", 1)), int(date.get("day", 1))]
+
+
+func _team_name_from_scouting_pool(team_id: String) -> String:
+	var teams = _get_scouting_teams(GameManager.current_career_phase)
+	for team in teams:
+		if team.get("id", "") == team_id:
+			return team.get("name", "Unknown")
+	return "Unknown"

--- a/scripts/core/game_manager.gd
+++ b/scripts/core/game_manager.gd
@@ -62,6 +62,9 @@ func change_state(new_state: GameState) -> void:
 
 
 func start_new_career(player_name: String, position: String, nationality: String = "USA", appearance: Dictionary = {}, dominant_foot: String = "right", traits: Array[String] = [], prefecture: String = "Kanagawa") -> void:
+	if CareerManager and CareerManager.has_method("reset_for_new_career"):
+		CareerManager.reset_for_new_career()
+
 	player_data = PlayerData.new()
 	player_data.initialize(player_name, position, nationality, appearance, dominant_foot, traits)
 	current_career_phase = CareerPhase.HIGH_SCHOOL
@@ -99,6 +102,7 @@ func end_match(result: Dictionary) -> void:
 	# Process match results
 	StatSystem.process_match_performance(result)
 	CareerManager.record_match_result(result)
+	SocialFeedManager.on_match_ended(result)
 	
 	# Generate post-match narrative
 	NarrativeEngine.generate_post_match_narrative(result)

--- a/scripts/core/injury_system.gd
+++ b/scripts/core/injury_system.gd
@@ -2,42 +2,105 @@ extends RefCounted
 class_name InjurySystem
 ## InjurySystem - Handles injury mechanics for NPC players
 
-const INJURY_TYPES = {
+const INJURY_CATEGORIES = {
 	"minor": {
-		"matches_out": [1, 2],
-		"descriptions": ["slight knock", "minor fatigue", "muscle tightness", "light bruising"]
+		"base_weight": 72,
+		"types": {
+			"muscle_tightness": {
+				"descriptions": ["muscle tightness", "minor strain", "mild stiffness"],
+				"weight": 30,
+				"matches_out": 1
+			},
+			"light_bruising": {
+				"descriptions": ["minor bruise", "light bruising", "soft tissue soreness"],
+				"weight": 30,
+				"matches_out": 1
+			},
+			"ankle_niggle": {
+				"descriptions": ["ankle niggle", "low-grade ankle soreness", "slight stiffness"],
+				"weight": 25,
+				"matches_out": 2
+			},
+			"minor_cramp": {
+				"descriptions": ["minor cramp", "hamstring pull", "tight calf"],
+				"weight": 15,
+				"matches_out": 2
+			}
+		}
 	},
 	"moderate": {
-		"matches_out": [2, 4],
-		"descriptions": ["ankle sprain", "muscle strain", "knee twist", "hamstring pull"]
+		"base_weight": 22,
+		"types": {
+			"ankle_sprain": {
+				"descriptions": ["ankle sprain", "rolled ankle", "ankle ligament stress"],
+				"weight": 30,
+				"matches_out": 2
+			},
+			"hamstring_pull": {
+				"descriptions": ["hamstring pull", "rear-thigh strain", "high-intensity hamstring pain"],
+				"weight": 25,
+				"matches_out": 3
+			},
+			"knee_twist": {
+				"descriptions": ["knee twist", "minor meniscus irritation", "knee instability"],
+				"weight": 25,
+				"matches_out": 3
+			},
+			"quadriceps_strain": {
+				"descriptions": ["quadriceps strain", "strained quad", "front-thigh inflammation"],
+				"weight": 20,
+				"matches_out": 4
+			}
+		}
 	},
 	"severe": {
-		"matches_out": [4, 8],
-		"descriptions": ["hamstring tear", "ligament damage", "fractured metatarsal", "ACL sprain"]
+		"base_weight": 6,
+		"types": {
+			"acl_tear": {
+				"descriptions": ["ACL tear", "major ligament tear", "serious knee injury"],
+				"weight": 25,
+				"matches_out": 12
+			},
+			"hamstring_tear": {
+				"descriptions": ["hamstring tear", "severe posterior muscle tear", "significant tear"],
+				"weight": 25,
+				"matches_out": 6
+			},
+			"ligament_damage": {
+				"descriptions": ["ligament damage", "major joint damage", "internal knee disruption"],
+				"weight": 25,
+				"matches_out": 9
+			},
+			"fractured_metatarsal": {
+				"descriptions": ["fractured metatarsal", "foot fracture", "metatarsal stress fracture"],
+				"weight": 25,
+				"matches_out": 10
+			}
+		}
 	}
 }
 
-# Base injury probability per player per match (2%)
-const BASE_INJURY_CHANCE: float = 0.02
+## Base injury chance per player per training session
+const BASE_TRAINING_INJURY_CHANCE_PER_PLAYER: float = 0.0016
 
-# Injury type weights (higher = more common)
-const INJURY_TYPE_WEIGHTS = {
-	"minor": 60,
-	"moderate": 30,
-	"severe": 10
-}
+## Hard cap for injury chance per player in a training session
+const MAX_TRAINING_INJURY_CHANCE_PER_PLAYER: float = 0.02
 
 
-## Roll for injuries after a match
-## Returns array of injury dictionaries for affected players
+## Legacy match injury API kept for call-site compatibility.
+## Match-level injury rolls were moved out; this now always returns no injuries.
 static func roll_for_injuries(team: TeamData, match_intensity: float = 1.0) -> Array[Dictionary]:
-	var injuries: Array[Dictionary] = []
+	return []
 
+
+## Roll for injuries specifically during training sessions.
+static func roll_for_training_injuries(team: TeamData, training_context: Dictionary = {}) -> Array[Dictionary]:
 	if not team or team.players.is_empty():
-		return injuries
+		return []
 
-	# Adjust injury chance based on match intensity
-	var injury_chance = BASE_INJURY_CHANCE * match_intensity
+	var injuries: Array[Dictionary] = []
+	var context = training_context.duplicate(true)
+	context["training_type"] = context.get("training_type", "practice")
 
 	for player in team.players:
 		var player_id = player.get("id", "")
@@ -50,52 +113,146 @@ static func roll_for_injuries(team: TeamData, match_intensity: float = 1.0) -> A
 			if npc.get("status", "active") != "active":
 				continue
 
-		# Roll for injury
-		if randf() < injury_chance:
-			var injury = generate_injury(player_id)
+		if randf() < _calculate_training_injury_chance(context):
+			var injury = generate_injury(player_id, context)
 			if not injury.is_empty():
 				injuries.append(injury)
 
 	return injuries
 
 
-## Generate an injury for a specific player
-static func generate_injury(npc_id: String) -> Dictionary:
-	var injury_type = _roll_injury_type()
-	var type_data = INJURY_TYPES.get(injury_type, INJURY_TYPES["minor"])
+## Process a full injury cycle for a training session: roll, apply, and return display events.
+static func process_training_injuries(team: TeamData, training_context: Dictionary = {}) -> Array[Dictionary]:
+	var injuries = roll_for_training_injuries(team, training_context)
+	if injuries.is_empty():
+		return []
 
-	var matches_range = type_data.get("matches_out", [1, 2])
-	var matches_out = randi_range(matches_range[0], matches_range[1])
+	apply_injuries(injuries)
+
+	var team_name = ""
+	var team_id = ""
+	if team:
+		team_name = team.name
+		team_id = team.id
+
+	var injury_events: Array[Dictionary] = []
+	for injury in injuries:
+		var npc_id = injury.get("npc_id", "")
+		if npc_id == "":
+			continue
+
+		var npc = NpcRegistry.get_npc(npc_id)
+		var player_name = npc.get("name", "Player")
+		var severity = injury.get("type", "minor")
+		var specific_injury = injury.get("injury_type", severity)
+		var matches_out = injury.get("matches_out", 1)
+
+		if severity == "severe":
+			NpcRegistry.record_career_event(npc_id, "severe_injury")
+
+		injury_events.append({
+			"team_id": team_id,
+			"team_name": team_name,
+			"player_name": player_name,
+			"description": injury.get("description", "injury"),
+			"matches_out": matches_out,
+			"type": severity,
+			"injury_type": specific_injury
+		})
+
+	return injury_events
+
+
+## Generate an injury for a specific player from training context.
+static func generate_injury(npc_id: String, training_context: Dictionary = {}) -> Dictionary:
+	var severity = _roll_injury_severity(training_context)
+	var injury_type = _roll_injury_type(severity)
+	var type_data = INJURY_CATEGORIES.get(severity, {}).get("types", {}).get(injury_type, {})
 
 	var descriptions = type_data.get("descriptions", ["injury"])
 	var description = descriptions[randi() % descriptions.size()]
+	var matches_out = int(type_data.get("matches_out", 1))
 
 	return {
 		"npc_id": npc_id,
-		"type": injury_type,
+		"type": severity,
+		"injury_type": injury_type,
 		"matches_out": matches_out,
 		"description": description
 	}
 
 
-## Roll for injury type based on weights
-static func _roll_injury_type() -> String:
+static func _calculate_training_injury_chance(training_context: Dictionary) -> float:
+	var accuracy = clampf(float(training_context.get("accuracy", 1.0)), 0.0, 1.0)
+	var attempts = maxi(1, int(training_context.get("attempts", TrainingConstants.ATTEMPTS_PER_SESSION)))
+	var intensity = clampf(float(training_context.get("training_intensity", 1.0)), 0.5, 2.0)
+	var stamina_before = clampi(int(training_context.get("player_stamina", 100)), 0, 100)
+	var stamina_cost = float(training_context.get("stamina_cost", TrainingConstants.STAMINA_COST))
+
+	var fatigue_factor = 1.0 + ((100.0 - float(stamina_before)) / 100.0) * 1.5
+	var quality_factor = 1.0 + ((1.0 - accuracy) * 0.75)
+	var volume_factor = clampf(float(attempts) / float(TrainingConstants.ATTEMPTS_PER_SESSION), 0.5, 2.0)
+	var cost_factor = clampf(0.6 + (stamina_cost / float(TrainingConstants.STAMINA_COST)), 0.6, 2.0)
+
+	var chance = BASE_TRAINING_INJURY_CHANCE_PER_PLAYER
+	chance *= intensity
+	chance *= fatigue_factor
+	chance *= quality_factor
+	chance *= volume_factor
+	chance *= cost_factor
+
+	return clampf(chance, 0.0, MAX_TRAINING_INJURY_CHANCE_PER_PLAYER)
+
+
+static func _roll_injury_severity(training_context: Dictionary) -> String:
+	var accuracy = clampf(float(training_context.get("accuracy", 1.0)), 0.0, 1.0)
+	var stamina_before = clampi(int(training_context.get("player_stamina", 100)), 0, 100)
+	var intensity = clampf(float(training_context.get("training_intensity", 1.0)), 0.5, 2.0)
+
+	var fatigue = 1.0 - (float(stamina_before) / 100.0)
+	var performance_pressure = 1.0 - accuracy
+	var stress = (intensity - 1.0) * 0.8 + fatigue + performance_pressure
+
+	var minor_weight = 72.0 - (stress * 25.0)
+	var moderate_weight = 22.0 + (stress * 18.0)
+	var severe_weight = 6.0 + (stress * 8.0)
+
+	minor_weight = max(10.0, minor_weight)
+	var total_weight = minor_weight + moderate_weight + severe_weight
+
+	var roll = randf() * total_weight
+	if roll < minor_weight:
+		return "minor"
+	elif roll < minor_weight + moderate_weight:
+		return "moderate"
+	return "severe"
+
+
+## Roll for injury type based on severity weights
+static func _roll_injury_type(injury_severity: String) -> String:
+	var severity_data = INJURY_CATEGORIES.get(injury_severity, {})
+	var type_data = severity_data.get("types", {})
+
 	var total_weight = 0
-	for type_name in INJURY_TYPE_WEIGHTS:
-		total_weight += INJURY_TYPE_WEIGHTS[type_name]
+	for type_name in type_data:
+		var details = type_data[type_name]
+		total_weight += int(details.get("weight", 1))
+
+	if total_weight == 0:
+		return injury_severity
 
 	var roll = randi() % total_weight
 	var cumulative = 0
-
-	for type_name in INJURY_TYPE_WEIGHTS:
-		cumulative += INJURY_TYPE_WEIGHTS[type_name]
+	for type_name in type_data:
+		var type_details = type_data[type_name]
+		cumulative += int(type_details.get("weight", 1))
 		if roll < cumulative:
 			return type_name
 
-	return "minor"
+	return type_data.keys()[0]
 
 
-## Get match intensity based on match type and competition stage
+## Get match intensity (legacy helper retained; injuries now come from training events).
 static func get_match_intensity(match_type: String, competition_stage: String = "") -> float:
 	var base_intensity = 1.0
 
@@ -132,7 +289,8 @@ static func apply_injuries(injuries: Array[Dictionary]) -> void:
 			npc_id,
 			injury.get("type", "minor"),
 			injury.get("matches_out", 1),
-			injury.get("description", "injury")
+			injury.get("description", "injury"),
+			injury.get("injury_type", "")
 		)
 
 

--- a/scripts/core/npc_registry.gd
+++ b/scripts/core/npc_registry.gd
@@ -103,7 +103,9 @@ func get_or_create_npc(stable_team_id: String, position: String, roster_index: i
 	# Injury tracking
 	new_npc["injury"] = npc_data.get("injury", {
 		"type": "",
+		"injury_type": "",
 		"matches_remaining": 0,
+		"matches_total": 0,
 		"description": ""
 	})
 
@@ -243,6 +245,7 @@ func apply_injury(npc_id: String, injury_type: String, matches_out: int, descrip
 		"type": injury_type,
 		"injury_type": specific_injury_type,
 		"matches_remaining": matches_out,
+		"matches_total": matches_out,
 		"description": description
 	}
 
@@ -267,6 +270,7 @@ func recover_from_injury(npc_id: String) -> void:
 		"type": "",
 		"injury_type": "",
 		"matches_remaining": 0,
+		"matches_total": 0,
 		"description": ""
 	}
 	npc["status"] = "active"
@@ -379,6 +383,25 @@ func is_npc_available(npc_id: String) -> bool:
 
 	var npc = npc_registry[npc_id]
 	return npc.get("status", "active") == "active"
+
+
+## Check if an NPC can be selected for match play.
+## Minor injuries are playable; all other injuries are unavailable.
+func is_npc_match_eligible(npc_id: String) -> bool:
+	if npc_id not in npc_registry:
+		return true  # Unknown NPCs are assumed available
+
+	var npc = npc_registry[npc_id]
+	var status = npc.get("status", "active")
+	if status == "active":
+		return true
+	if status != "injured":
+		return false
+
+	var injury = npc.get("injury", {})
+	var severity = injury.get("type", "")
+	var matches_remaining = int(injury.get("matches_remaining", 0))
+	return severity == "minor" and matches_remaining > 0
 
 
 ## Get the current season year from the season ID

--- a/scripts/core/npc_registry.gd
+++ b/scripts/core/npc_registry.gd
@@ -235,12 +235,13 @@ func get_active_team_npcs(stable_team_id: String) -> Array[Dictionary]:
 
 
 ## Apply an injury to an NPC
-func apply_injury(npc_id: String, injury_type: String, matches_out: int, description: String = "") -> void:
+func apply_injury(npc_id: String, injury_type: String, matches_out: int, description: String = "", specific_injury_type: String = "") -> void:
 	if npc_id not in npc_registry:
 		return
 
 	var injury = {
 		"type": injury_type,
+		"injury_type": specific_injury_type,
 		"matches_remaining": matches_out,
 		"description": description
 	}
@@ -264,6 +265,7 @@ func recover_from_injury(npc_id: String) -> void:
 
 	npc["injury"] = {
 		"type": "",
+		"injury_type": "",
 		"matches_remaining": 0,
 		"description": ""
 	}

--- a/scripts/core/save_manager.gd
+++ b/scripts/core/save_manager.gd
@@ -7,7 +7,7 @@ signal load_completed(slot: int, success: bool)
 const SAVE_DIR = "user://saves/"
 const SAVE_EXTENSION = ".sav"
 const MAX_SAVE_SLOTS = 5
-const SAVE_VERSION = 1
+const SAVE_VERSION = 2
 
 var current_slot: int = -1
 var auto_save_enabled: bool = true
@@ -238,7 +238,14 @@ func _serialize_career() -> Dictionary:
 		"match_history": CareerManager.match_history,
 		"career_stats": CareerManager.career_stats,
 		"reputation": CareerManager.reputation,
+		"media_coverage": CareerManager.media_coverage,
+		"fan_popularity": CareerManager.fan_popularity,
 		"scout_attention": CareerManager.scout_attention,
+		"reputation_event_log": CareerManager.reputation_event_log,
+		"last_match_reputation_report": CareerManager.last_match_reputation_report,
+		"social_rep_day_key": CareerManager.social_rep_day_key,
+		"social_rep_awarded_today": CareerManager.social_rep_awarded_today,
+		"social_rep_actions_today": CareerManager.social_rep_actions_today,
 		"completed_milestones": CareerManager.completed_milestones,
 		"rivals": CareerManager.rivals
 	}
@@ -296,7 +303,14 @@ func _apply_save_data(data: Dictionary) -> void:
 		CareerManager.match_history.assign(career.get("match_history", []))
 		CareerManager.career_stats = career.get("career_stats", {})
 		CareerManager.reputation = career.get("reputation", 10)
+		CareerManager.media_coverage = career.get("media_coverage", 0)
+		CareerManager.fan_popularity = career.get("fan_popularity", 0)
 		CareerManager.scout_attention = career.get("scout_attention", {})
+		CareerManager.reputation_event_log.assign(career.get("reputation_event_log", []))
+		CareerManager.last_match_reputation_report = career.get("last_match_reputation_report", {})
+		CareerManager.social_rep_day_key = career.get("social_rep_day_key", "")
+		CareerManager.social_rep_awarded_today = int(career.get("social_rep_awarded_today", 0))
+		CareerManager.social_rep_actions_today = int(career.get("social_rep_actions_today", 0))
 		CareerManager.completed_milestones.assign(career.get("completed_milestones", []))
 		CareerManager.rivals.assign(career.get("rivals", []))
 

--- a/scripts/core/save_manager.gd
+++ b/scripts/core/save_manager.gd
@@ -208,6 +208,9 @@ func _collect_save_data() -> Dictionary:
 		# NPC Registry (persistent NPC identities)
 		"npc_registry": NpcRegistry.to_dict(),
 
+		# Social feed
+		"social_feed": SocialFeedManager.to_dict(),
+
 		# Settings
 		"settings": _serialize_settings()
 	}
@@ -309,9 +312,13 @@ func _apply_save_data(data: Dictionary) -> void:
 	if "personas" in data:
 		PersonaManager.load_personas_from_dict(data.personas)
 
-	# Restore NPC Registry (must be before team restoration for cross-reference)
+	# Restore NPC Registry
 	if "npc_registry" in data:
 		NpcRegistry.from_dict(data.npc_registry)
+
+	# Restore social feed
+	if "social_feed" in data:
+		SocialFeedManager.from_dict(data.social_feed)
 
 	# Restore settings
 	if "settings" in data:

--- a/scripts/dashboard/components/player_mini_card.gd
+++ b/scripts/dashboard/components/player_mini_card.gd
@@ -6,6 +6,8 @@ class_name PlayerMiniCard
 @onready var name_label: Label = $MarginContainer/HBoxContainer/InfoContainer/NameLabel
 @onready var position_label: Label = $MarginContainer/HBoxContainer/InfoContainer/PositionRow/PositionLabel
 @onready var overall_label: Label = $MarginContainer/HBoxContainer/InfoContainer/PositionRow/OverallLabel
+@onready var reputation_label: Label = $MarginContainer/HBoxContainer/InfoContainer/ReputationRow/ReputationLabel
+@onready var reputation_tier_label: Label = $MarginContainer/HBoxContainer/InfoContainer/ReputationRow/ReputationTierLabel
 @onready var form_indicator: ColorRect = $MarginContainer/HBoxContainer/InfoContainer/FormRow/FormIndicator
 @onready var form_label: Label = $MarginContainer/HBoxContainer/InfoContainer/FormRow/FormLabel
 @onready var stamina_bar: ProgressBar = $MarginContainer/HBoxContainer/InfoContainer/StaminaRow/StaminaBar
@@ -29,10 +31,16 @@ func _setup_style() -> void:
 
 
 func _connect_signals() -> void:
-	if StatSystem.stat_changed.is_connected(_on_stat_changed):
-		return
-	StatSystem.stat_changed.connect(_on_stat_changed)
-	StatSystem.level_up.connect(_on_level_up)
+	if not StatSystem.stat_changed.is_connected(_on_stat_changed):
+		StatSystem.stat_changed.connect(_on_stat_changed)
+	if not StatSystem.level_up.is_connected(_on_level_up):
+		StatSystem.level_up.connect(_on_level_up)
+	if CareerManager and CareerManager.has_signal("reputation_changed"):
+		if not CareerManager.reputation_changed.is_connected(_on_reputation_changed):
+			CareerManager.reputation_changed.connect(_on_reputation_changed)
+	if CareerManager and CareerManager.has_signal("reputation_tier_changed"):
+		if not CareerManager.reputation_tier_changed.is_connected(_on_reputation_tier_changed):
+			CareerManager.reputation_tier_changed.connect(_on_reputation_tier_changed)
 
 
 func _on_stat_changed(_player_id: String, _stat_name: String, _old_value: int, _new_value: int) -> void:
@@ -40,6 +48,14 @@ func _on_stat_changed(_player_id: String, _stat_name: String, _old_value: int, _
 
 
 func _on_level_up(_player_id: String, _new_level: int) -> void:
+	_refresh_display()
+
+
+func _on_reputation_changed(_new_value: int) -> void:
+	_refresh_display()
+
+
+func _on_reputation_tier_changed(_old_tier: String, _new_tier: String) -> void:
 	_refresh_display()
 
 
@@ -63,6 +79,21 @@ func _refresh_display() -> void:
 		var ovr = player.get_overall()
 		overall_label.text = "OVR %d" % ovr
 		overall_label.add_theme_color_override("font_color", _get_overall_color(ovr))
+
+	# Reputation
+	var rep_score = 10
+	var rep_tier_name = "Unknown"
+	if CareerManager:
+		rep_score = int(CareerManager.reputation)
+		if CareerManager.has_method("get_reputation_tier"):
+			var tier = CareerManager.get_reputation_tier()
+			rep_tier_name = str(tier.get("name", "Unknown"))
+	if reputation_label:
+		reputation_label.text = "REP %d" % rep_score
+		reputation_label.add_theme_color_override("font_color", _get_reputation_color(rep_score))
+	if reputation_tier_label:
+		reputation_tier_label.text = rep_tier_name
+		reputation_tier_label.add_theme_color_override("font_color", _get_reputation_color(rep_score).lightened(0.2))
 
 	# Form
 	if form_indicator and form_label:
@@ -88,6 +119,10 @@ func _show_placeholder() -> void:
 		position_label.text = "---"
 	if overall_label:
 		overall_label.text = "OVR --"
+	if reputation_label:
+		reputation_label.text = "REP --"
+	if reputation_tier_label:
+		reputation_tier_label.text = "---"
 	if form_label:
 		form_label.text = "---"
 	if stamina_bar:
@@ -146,3 +181,17 @@ func _get_stamina_color(stamina: int) -> Color:
 		return Color(1.0, 0.9, 0.3)  # Yellow
 	else:
 		return Color(1.0, 0.4, 0.4)  # Red
+
+
+func _get_reputation_color(score: int) -> Color:
+	if score >= 85:
+		return Color(1.0, 0.75, 0.2)
+	elif score >= 70:
+		return Color(0.95, 0.6, 0.25)
+	elif score >= 50:
+		return Color(0.4, 0.8, 1.0)
+	elif score >= 30:
+		return Color(0.45, 0.9, 0.55)
+	elif score >= 15:
+		return Color(0.9, 0.9, 0.4)
+	return Color(0.65, 0.7, 0.78)

--- a/scripts/dashboard/console_dashboard.gd
+++ b/scripts/dashboard/console_dashboard.gd
@@ -169,7 +169,10 @@ func _on_tile_pressed(tile_id: String) -> void:
 	for config in TILE_CONFIG:
 		if config.id == tile_id:
 			if config.has("panel"):
-				_open_panel(config.panel)
+				if config.id == "social" and SocialFeedManager and SocialFeedManager.is_v2_enabled():
+					_open_panel("res://scenes/dashboard/panels/panel_social_v2.tscn")
+				else:
+					_open_panel(config.panel)
 			elif config.has("scene"):
 				_open_scene(config.scene)
 			return

--- a/scripts/dashboard/console_dashboard.gd
+++ b/scripts/dashboard/console_dashboard.gd
@@ -13,6 +13,7 @@ const TILE_CONFIG: Array[Dictionary] = [
 	{"id": "email", "title": "Email", "icon": "res://assets/ui/icons/icon_email.svg", "panel": "res://scenes/dashboard/panels/panel_email.tscn"},
 	{"id": "desktop", "title": "Desktop", "icon": "res://assets/ui/icons/icon_settings.svg", "scene": "res://scenes/desktop/desktop_shell.tscn"},
 	{"id": "career_hub", "title": "Career Hub", "icon": "res://assets/ui/icons/icon_team.svg", "scene": "res://scenes/career/career_hub.tscn"},
+	{"id": "social", "title": "FanZone", "icon": "res://assets/ui/icons/icon_team.svg", "panel": "res://scenes/dashboard/panels/panel_social.tscn"},
 	{"id": "save", "title": "Save", "icon": "res://assets/ui/icons/icon_save.svg", "panel": "res://scenes/dashboard/panels/panel_save_load.tscn"},
 	{"id": "settings", "title": "Settings", "icon": "res://assets/ui/icons/icon_settings.svg", "panel": "res://scenes/dashboard/panels/panel_settings.tscn"}
 ]

--- a/scripts/dashboard/panels/panel_social.gd
+++ b/scripts/dashboard/panels/panel_social.gd
@@ -1,10 +1,46 @@
 extends PanelBase
 class_name PanelSocial
-## PanelSocial - Social media / FanZone panel
+## PanelSocial - Social media / FanZone panel with feed, compose, threads, and filters
 
+enum ViewState { FEED, THREAD }
+
+@onready var main_content: VBoxContainer = $ContentContainer/MarginContainer/VBoxContainer/ContentArea/MainContent
 @onready var feed_container: VBoxContainer = $ContentContainer/MarginContainer/VBoxContainer/ContentArea/MainContent/ScrollContainer/FeedContainer
+@onready var scroll_container: ScrollContainer = $ContentContainer/MarginContainer/VBoxContainer/ContentArea/MainContent/ScrollContainer
+@onready var thread_view: VBoxContainer = $ContentContainer/MarginContainer/VBoxContainer/ContentArea/ThreadView
 
-var news_articles: Array[Dictionary] = []
+var current_view: ViewState = ViewState.FEED
+var current_filter: String = "all"
+var current_thread_post_id: String = ""
+
+# UI references built programmatically
+var filter_bar: HBoxContainer
+var compose_area: VBoxContainer
+var compose_input: TextEdit
+var compose_button: Button
+var thread_scroll: ScrollContainer
+var thread_container: VBoxContainer
+var thread_reply_input: TextEdit
+var thread_reply_button: Button
+var thread_original_post: VBoxContainer
+
+# Filter buttons for highlighting
+var filter_buttons: Dictionary = {}
+
+# Colors
+const COLOR_BG_CARD := Color(0.06, 0.1, 0.18, 0.9)
+const COLOR_BG_CARD_HOVER := Color(0.08, 0.12, 0.22, 0.9)
+const COLOR_BORDER := Color(0.15, 0.25, 0.4)
+const COLOR_ACCENT_BLUE := Color(0.3, 0.6, 1)
+const COLOR_ACCENT_GREEN := Color(0.3, 0.8, 0.4)
+const COLOR_ACCENT_RED := Color(1, 0.4, 0.4)
+const COLOR_ACCENT_GOLD := Color(1, 0.85, 0.3)
+const COLOR_ACCENT_PURPLE := Color(0.7, 0.4, 1)
+const COLOR_TEXT_PRIMARY := Color(0.95, 0.97, 1)
+const COLOR_TEXT_SECONDARY := Color(0.75, 0.8, 0.85)
+const COLOR_TEXT_DIM := Color(0.5, 0.55, 0.6)
+const COLOR_PLAYER_ACCENT := Color(0.3, 0.7, 1)
+const COLOR_NEWS_ACCENT := Color(1, 0.6, 0.2)
 
 
 func _on_panel_ready() -> void:
@@ -14,156 +50,845 @@ func _on_panel_ready() -> void:
 
 
 func _on_panel_opened() -> void:
-	_connect_signals()
-	_load_articles()
-	_refresh_display()
+	_connect_feed_signals()
+	SocialFeedManager.ensure_welcome_post()
+	_build_filter_bar()
+	_build_compose_area()
+	_build_thread_view()
+	_refresh_feed()
 
 
-func _connect_signals() -> void:
-	if not NarrativeEngine.news_article_generated.is_connected(_on_news_article):
-		NarrativeEngine.news_article_generated.connect(_on_news_article)
+func _on_panel_closing() -> void:
+	_disconnect_feed_signals()
 
 
-func _load_articles() -> void:
-	if news_articles.is_empty():
-		# Add default welcome post
-		news_articles.append({
-			"headline": "A New Star Joins the Ranks!",
-			"body": "The local football community is buzzing with excitement as a promising young talent begins their career journey. We'll be following their progress closely!",
-			"author": "FanZone Staff",
-			"date": DesktopManager.get_date_string(),
-			"likes": randi_range(50, 200),
-			"comments": randi_range(10, 50)
-		})
+func _connect_feed_signals() -> void:
+	if not SocialFeedManager.post_added.is_connected(_on_post_added):
+		SocialFeedManager.post_added.connect(_on_post_added)
+	if not SocialFeedManager.reply_added.is_connected(_on_reply_added):
+		SocialFeedManager.reply_added.connect(_on_reply_added)
+	if not SocialFeedManager.feed_refreshed.is_connected(_on_feed_refreshed):
+		SocialFeedManager.feed_refreshed.connect(_on_feed_refreshed)
 
 
-func _refresh_display() -> void:
+func _disconnect_feed_signals() -> void:
+	if SocialFeedManager.post_added.is_connected(_on_post_added):
+		SocialFeedManager.post_added.disconnect(_on_post_added)
+	if SocialFeedManager.reply_added.is_connected(_on_reply_added):
+		SocialFeedManager.reply_added.disconnect(_on_reply_added)
+	if SocialFeedManager.feed_refreshed.is_connected(_on_feed_refreshed):
+		SocialFeedManager.feed_refreshed.disconnect(_on_feed_refreshed)
+
+
+# ─── Input Handling ──────────────────────────────────────────────
+
+func _input(event: InputEvent) -> void:
+	if not is_open:
+		return
+
+	if event.is_action_pressed("ui_cancel") or event.is_action_pressed("ui_back"):
+		if current_view == ViewState.THREAD:
+			_show_feed_view()
+			get_viewport().set_input_as_handled()
+			return
+
+	# Let base class handle close for feed view
+	super._input(event)
+
+
+# ─── Filter Bar ──────────────────────────────────────────────────
+
+func _build_filter_bar() -> void:
+	if filter_bar:
+		return  # Already built
+
+	filter_bar = HBoxContainer.new()
+	filter_bar.add_theme_constant_override("separation", 8)
+	main_content.add_child(filter_bar)
+	main_content.move_child(filter_bar, 0)
+
+	var filters = [
+		{"id": "all", "label": "All"},
+		{"id": "npc", "label": "NPC"},
+		{"id": "news", "label": "News"},
+		{"id": "my_posts", "label": "My Posts"}
+	]
+
+	for f in filters:
+		var btn = Button.new()
+		btn.text = f.label
+		btn.custom_minimum_size = Vector2(80, 32)
+		btn.add_theme_font_size_override("font_size", 13)
+		btn.pressed.connect(_on_filter_pressed.bind(f.id))
+		_style_filter_button(btn, f.id == current_filter)
+		filter_bar.add_child(btn)
+		filter_buttons[f.id] = btn
+
+	# Spacer
+	var spacer = Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	filter_bar.add_child(spacer)
+
+
+func _style_filter_button(btn: Button, active: bool) -> void:
+	var style = StyleBoxFlat.new()
+	if active:
+		style.bg_color = COLOR_ACCENT_BLUE.darkened(0.4)
+		style.border_color = COLOR_ACCENT_BLUE
+		btn.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	else:
+		style.bg_color = Color(0.08, 0.12, 0.2)
+		style.border_color = COLOR_BORDER
+		btn.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	style.set_border_width_all(1)
+	style.set_corner_radius_all(4)
+	style.set_content_margin_all(4)
+	btn.add_theme_stylebox_override("normal", style)
+
+	var hover = style.duplicate()
+	hover.bg_color = hover.bg_color.lightened(0.1)
+	btn.add_theme_stylebox_override("hover", hover)
+	btn.add_theme_stylebox_override("pressed", style)
+
+
+func _on_filter_pressed(filter_id: String) -> void:
+	AudioManager.play_ui_click()
+	current_filter = filter_id
+	for fid in filter_buttons:
+		_style_filter_button(filter_buttons[fid], fid == current_filter)
+	_refresh_feed()
+
+
+# ─── Compose Area ────────────────────────────────────────────────
+
+func _build_compose_area() -> void:
+	if compose_area:
+		return
+
+	var main_content = feed_container.get_parent().get_parent()
+
+	compose_area = VBoxContainer.new()
+	compose_area.add_theme_constant_override("separation", 8)
+
+	var card = PanelContainer.new()
+	var card_style = StyleBoxFlat.new()
+	card_style.bg_color = Color(0.05, 0.08, 0.15, 0.9)
+	card_style.set_border_width_all(1)
+	card_style.border_color = COLOR_ACCENT_BLUE.darkened(0.3)
+	card_style.set_corner_radius_all(8)
+	card_style.set_content_margin_all(12)
+	card.add_theme_stylebox_override("panel", card_style)
+
+	var inner = VBoxContainer.new()
+	inner.add_theme_constant_override("separation", 8)
+
+	var header_label = Label.new()
+	header_label.text = "What's on your mind?"
+	header_label.add_theme_font_size_override("font_size", 13)
+	header_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	inner.add_child(header_label)
+
+	compose_input = TextEdit.new()
+	compose_input.placeholder_text = "Share your thoughts with the team..."
+	compose_input.custom_minimum_size = Vector2(0, 60)
+	compose_input.add_theme_font_size_override("font_size", 14)
+	compose_input.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	var input_style = StyleBoxFlat.new()
+	input_style.bg_color = Color(0.04, 0.06, 0.12)
+	input_style.set_border_width_all(1)
+	input_style.border_color = COLOR_BORDER
+	input_style.set_corner_radius_all(4)
+	input_style.set_content_margin_all(8)
+	compose_input.add_theme_stylebox_override("normal", input_style)
+	compose_input.add_theme_stylebox_override("focus", input_style)
+	inner.add_child(compose_input)
+
+	var btn_row = HBoxContainer.new()
+	var btn_spacer = Control.new()
+	btn_spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	btn_row.add_child(btn_spacer)
+
+	compose_button = Button.new()
+	compose_button.text = "Post"
+	compose_button.custom_minimum_size = Vector2(80, 32)
+	_style_action_button(compose_button, COLOR_ACCENT_BLUE)
+	compose_button.pressed.connect(_on_compose_submit)
+	btn_row.add_child(compose_button)
+	inner.add_child(btn_row)
+
+	card.add_child(inner)
+	compose_area.add_child(card)
+
+	# Insert after filter bar
+	var insert_idx = 1 if filter_bar else 0
+	main_content.add_child(compose_area)
+	main_content.move_child(compose_area, insert_idx)
+
+
+func _on_compose_submit() -> void:
+	var text = compose_input.text.strip_edges()
+	if text.is_empty():
+		return
+
+	AudioManager.play_ui_click()
+	SocialFeedManager.create_player_post(text)
+	compose_input.text = ""
+
+
+# ─── Feed Display ────────────────────────────────────────────────
+
+func _refresh_feed() -> void:
 	if not feed_container:
 		return
 
 	for child in feed_container.get_children():
 		child.queue_free()
 
-	if news_articles.is_empty():
+	var posts = SocialFeedManager.get_feed(current_filter)
+
+	if posts.is_empty():
 		var empty_label = Label.new()
 		empty_label.text = "No posts yet. Play matches to generate news!"
-		empty_label.add_theme_color_override("font_color", Color(0.5, 0.55, 0.6))
+		empty_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
 		feed_container.add_child(empty_label)
 		return
 
-	for article in news_articles:
-		_add_article_card(article)
+	for post in posts:
+		var card = _create_post_card(post)
+		feed_container.add_child(card)
 
 
-func _add_article_card(article: Dictionary) -> void:
+func _create_post_card(post: Dictionary) -> PanelContainer:
+	var post_type = post.get("post_type", "")
+
+	match post_type:
+		"match_summary":
+			return _create_match_summary_card(post)
+		"news_article":
+			return _create_news_card(post)
+		"milestone":
+			return _create_milestone_card(post)
+		"fan_reaction":
+			return _create_fan_card(post)
+		"player_post":
+			return _create_player_card(post)
+		"injury_report":
+			return _create_injury_card(post)
+		"season_update":
+			return _create_season_update_card(post)
+		_:
+			return _create_npc_card(post)
+
+
+func _create_base_card(border_color: Color = COLOR_BORDER) -> PanelContainer:
 	var panel = PanelContainer.new()
 	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.06, 0.1, 0.18, 0.9)
+	style.bg_color = COLOR_BG_CARD
 	style.set_border_width_all(1)
-	style.border_color = Color(0.15, 0.25, 0.4)
+	style.border_color = border_color
 	style.set_corner_radius_all(8)
-	style.set_content_margin_all(16)
+	style.set_content_margin_all(14)
 	panel.add_theme_stylebox_override("panel", style)
+	return panel
 
+
+func _create_npc_card(post: Dictionary) -> PanelContainer:
+	var role = post.get("author_role", "teammate")
+	var border_color = COLOR_ACCENT_GREEN if role == "teammate" else COLOR_ACCENT_RED
+	if role == "coach":
+		border_color = COLOR_ACCENT_BLUE
+
+	var panel = _create_base_card(border_color)
 	var vbox = VBoxContainer.new()
-	vbox.add_theme_constant_override("separation", 10)
+	vbox.add_theme_constant_override("separation", 8)
+
+	# Author row
+	var author_row = _create_author_row(post, border_color)
+	vbox.add_child(author_row)
+
+	# Content
+	var content_label = _create_content_label(post.get("content", ""))
+	vbox.add_child(content_label)
+
+	# Engagement row
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_match_summary_card(post: Dictionary) -> PanelContainer:
+	var mood = post.get("mood", "neutral")
+	var border_color = COLOR_ACCENT_GREEN if mood == "happy" else COLOR_ACCENT_RED if mood == "sad" else COLOR_TEXT_DIM
+
+	var panel = _create_base_card(border_color)
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# Match badge
+	var badge_row = HBoxContainer.new()
+	var badge = _create_badge("MATCH", border_color)
+	badge_row.add_child(badge)
+	var date_label = Label.new()
+	date_label.text = "  " + post.get("date_string", "")
+	date_label.add_theme_font_size_override("font_size", 11)
+	date_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	badge_row.add_child(date_label)
+	vbox.add_child(badge_row)
+
+	# Score display
+	var score_label = Label.new()
+	score_label.text = post.get("content", "")
+	score_label.add_theme_font_size_override("font_size", 18)
+	score_label.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	score_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	vbox.add_child(score_label)
+
+	# Engagement row
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_news_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_NEWS_ACCENT.darkened(0.3))
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# News badge
+	var badge_row = HBoxContainer.new()
+	var badge = _create_badge("NEWS", COLOR_NEWS_ACCENT)
+	badge_row.add_child(badge)
+	var source = Label.new()
+	source.text = "  " + post.get("source", post.get("author_name", "FanZone"))
+	source.add_theme_font_size_override("font_size", 11)
+	source.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	badge_row.add_child(source)
+	vbox.add_child(badge_row)
 
 	# Headline
 	var headline = Label.new()
-	headline.text = article.headline
-	headline.add_theme_font_size_override("font_size", 18)
-	headline.add_theme_color_override("font_color", Color(0.95, 0.97, 1))
+	headline.text = post.get("headline", post.get("content", ""))
+	headline.add_theme_font_size_override("font_size", 17)
+	headline.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
 	headline.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	vbox.add_child(headline)
 
-	# Body
-	var body = Label.new()
-	body.text = article.body
-	body.add_theme_font_size_override("font_size", 14)
-	body.add_theme_color_override("font_color", Color(0.75, 0.8, 0.85))
-	body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-
-	# Meta row
-	var meta_row = HBoxContainer.new()
-	meta_row.add_theme_constant_override("separation", 16)
-
-	var author_label = Label.new()
-	author_label.text = "By %s" % article.author
-	author_label.add_theme_font_size_override("font_size", 12)
-	author_label.add_theme_color_override("font_color", Color(0.5, 0.55, 0.6))
-
-	var date_label = Label.new()
-	date_label.text = article.date
-	date_label.add_theme_font_size_override("font_size", 12)
-	date_label.add_theme_color_override("font_color", Color(0.5, 0.55, 0.6))
-
-	meta_row.add_child(author_label)
-	meta_row.add_child(date_label)
+	# Body preview
+	var body_text = post.get("body", "")
+	if body_text != "":
+		var body = Label.new()
+		body.text = body_text
+		body.add_theme_font_size_override("font_size", 13)
+		body.add_theme_color_override("font_color", COLOR_TEXT_SECONDARY)
+		body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		body.max_lines_visible = 3
+		vbox.add_child(body)
 
 	# Engagement row
-	var engagement_row = HBoxContainer.new()
-	engagement_row.add_theme_constant_override("separation", 20)
-
-	var likes_label = Label.new()
-	likes_label.text = "%d likes" % article.likes
-	likes_label.add_theme_font_size_override("font_size", 13)
-	likes_label.add_theme_color_override("font_color", Color(1, 0.4, 0.5))
-
-	var comments_label = Label.new()
-	comments_label.text = "%d comments" % article.comments
-	comments_label.add_theme_font_size_override("font_size", 13)
-	comments_label.add_theme_color_override("font_color", Color(0.4, 0.7, 1))
-
-	engagement_row.add_child(likes_label)
-	engagement_row.add_child(comments_label)
-
-	# Spacer for expand
-	var spacer = Control.new()
-	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	engagement_row.add_child(spacer)
-
-	# Like button
-	var like_btn = Button.new()
-	like_btn.text = "Like"
-	like_btn.custom_minimum_size = Vector2(60, 28)
-	var btn_style = StyleBoxFlat.new()
-	btn_style.bg_color = Color(0.1, 0.15, 0.25)
-	btn_style.set_border_width_all(1)
-	btn_style.border_color = Color(0.3, 0.4, 0.6)
-	btn_style.set_corner_radius_all(4)
-	like_btn.add_theme_stylebox_override("normal", btn_style)
-	like_btn.add_theme_color_override("font_color", Color(0.8, 0.85, 0.9))
-	like_btn.add_theme_font_size_override("font_size", 12)
-	like_btn.pressed.connect(_on_like_pressed.bind(article, likes_label))
-	engagement_row.add_child(like_btn)
-
-	vbox.add_child(headline)
-	vbox.add_child(body)
-	vbox.add_child(meta_row)
-	vbox.add_child(engagement_row)
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
 
 	panel.add_child(vbox)
-	feed_container.add_child(panel)
+	return panel
 
 
-func _on_like_pressed(article: Dictionary, label: Label) -> void:
+func _create_milestone_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_ACCENT_GOLD.darkened(0.2))
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# Achievement badge
+	var badge_row = HBoxContainer.new()
+	var badge = _create_badge("ACHIEVEMENT", COLOR_ACCENT_GOLD)
+	badge_row.add_child(badge)
+	vbox.add_child(badge_row)
+
+	# Content
+	var content_label = Label.new()
+	content_label.text = post.get("content", "")
+	content_label.add_theme_font_size_override("font_size", 16)
+	content_label.add_theme_color_override("font_color", COLOR_ACCENT_GOLD)
+	content_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	vbox.add_child(content_label)
+
+	# Engagement row
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_fan_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_BORDER)
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 6)
+
+	# Minimal author
+	var author_label = Label.new()
+	author_label.text = post.get("author_name", "Fan")
+	author_label.add_theme_font_size_override("font_size", 12)
+	author_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	vbox.add_child(author_label)
+
+	# Content
+	var content_label = _create_content_label(post.get("content", ""))
+	content_label.add_theme_font_size_override("font_size", 13)
+	vbox.add_child(content_label)
+
+	# Minimal engagement
+	var likes_label = Label.new()
+	likes_label.text = "%d likes" % post.get("likes", 0)
+	likes_label.add_theme_font_size_override("font_size", 11)
+	likes_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	vbox.add_child(likes_label)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_player_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_PLAYER_ACCENT)
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# "You" label
+	var author_row = HBoxContainer.new()
+	author_row.add_theme_constant_override("separation", 8)
+	var you_badge = _create_badge("YOU", COLOR_PLAYER_ACCENT)
+	author_row.add_child(you_badge)
+	var handle = Label.new()
+	handle.text = post.get("author_handle", "@you")
+	handle.add_theme_font_size_override("font_size", 12)
+	handle.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	author_row.add_child(handle)
+	var date_lbl = Label.new()
+	date_lbl.text = post.get("date_string", "")
+	date_lbl.add_theme_font_size_override("font_size", 11)
+	date_lbl.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	date_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	date_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	author_row.add_child(date_lbl)
+	vbox.add_child(author_row)
+
+	# Content
+	var content_label = _create_content_label(post.get("content", ""))
+	vbox.add_child(content_label)
+
+	# Engagement row
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_injury_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_ACCENT_RED.darkened(0.3))
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# Injury badge
+	var badge_row = HBoxContainer.new()
+	var badge = _create_badge("INJURY", COLOR_ACCENT_RED)
+	badge_row.add_child(badge)
+	vbox.add_child(badge_row)
+
+	# Content
+	var content_label = _create_content_label(post.get("content", ""))
+	vbox.add_child(content_label)
+
+	# Engagement
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _create_season_update_card(post: Dictionary) -> PanelContainer:
+	var panel = _create_base_card(COLOR_ACCENT_PURPLE.darkened(0.3))
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+
+	# Season badge
+	var badge_row = HBoxContainer.new()
+	var badge = _create_badge("SEASON", COLOR_ACCENT_PURPLE)
+	badge_row.add_child(badge)
+	vbox.add_child(badge_row)
+
+	# Content
+	var content_label = _create_content_label(post.get("content", ""))
+	content_label.add_theme_font_size_override("font_size", 15)
+	vbox.add_child(content_label)
+
+	# Engagement
+	var engagement = _create_engagement_row(post)
+	vbox.add_child(engagement)
+
+	panel.add_child(vbox)
+	return panel
+
+
+# ─── Shared Card Components ─────────────────────────────────────
+
+func _create_badge(text: String, color: Color) -> PanelContainer:
+	var badge_panel = PanelContainer.new()
+	var badge_style = StyleBoxFlat.new()
+	badge_style.bg_color = color.darkened(0.6)
+	badge_style.set_border_width_all(1)
+	badge_style.border_color = color.darkened(0.2)
+	badge_style.set_corner_radius_all(3)
+	badge_style.content_margin_left = 6
+	badge_style.content_margin_right = 6
+	badge_style.content_margin_top = 2
+	badge_style.content_margin_bottom = 2
+	badge_panel.add_theme_stylebox_override("panel", badge_style)
+
+	var badge_label = Label.new()
+	badge_label.text = text
+	badge_label.add_theme_font_size_override("font_size", 10)
+	badge_label.add_theme_color_override("font_color", color)
+	badge_panel.add_child(badge_label)
+
+	return badge_panel
+
+
+func _create_author_row(post: Dictionary, accent_color: Color) -> HBoxContainer:
+	var row = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+
+	# Role indicator dot
+	var dot = Label.new()
+	dot.text = "●"
+	dot.add_theme_font_size_override("font_size", 10)
+	dot.add_theme_color_override("font_color", accent_color)
+	row.add_child(dot)
+
+	# Author name
+	var name_label = Label.new()
+	name_label.text = post.get("author_name", "Unknown")
+	name_label.add_theme_font_size_override("font_size", 14)
+	name_label.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	row.add_child(name_label)
+
+	# Handle
+	var handle_label = Label.new()
+	handle_label.text = post.get("author_handle", "")
+	handle_label.add_theme_font_size_override("font_size", 12)
+	handle_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	row.add_child(handle_label)
+
+	# Spacer + date
+	var spacer = Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(spacer)
+
+	var date_label = Label.new()
+	date_label.text = post.get("date_string", "")
+	date_label.add_theme_font_size_override("font_size", 11)
+	date_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	row.add_child(date_label)
+
+	return row
+
+
+func _create_content_label(text: String) -> Label:
+	var label = Label.new()
+	label.text = text
+	label.add_theme_font_size_override("font_size", 14)
+	label.add_theme_color_override("font_color", COLOR_TEXT_SECONDARY)
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	return label
+
+
+func _create_engagement_row(post: Dictionary) -> HBoxContainer:
+	var row = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 16)
+
+	# Likes
+	var likes_btn = Button.new()
+	var is_liked = post.get("player_liked", false)
+	likes_btn.text = "%d %s" % [post.get("likes", 0), "Liked" if is_liked else "Like"]
+	likes_btn.add_theme_font_size_override("font_size", 12)
+	likes_btn.add_theme_color_override("font_color", COLOR_ACCENT_RED if is_liked else COLOR_TEXT_DIM)
+	_style_flat_button(likes_btn)
+	likes_btn.pressed.connect(_on_like_pressed.bind(post, likes_btn))
+	row.add_child(likes_btn)
+
+	# Reply count + button
+	var replies = post.get("replies", [])
+	var reply_btn = Button.new()
+	reply_btn.text = "%d Repl%s" % [replies.size(), "ies" if replies.size() != 1 else "y"]
+	reply_btn.add_theme_font_size_override("font_size", 12)
+	reply_btn.add_theme_color_override("font_color", COLOR_ACCENT_BLUE)
+	_style_flat_button(reply_btn)
+	reply_btn.pressed.connect(_on_reply_pressed.bind(post))
+	row.add_child(reply_btn)
+
+	# Spacer
+	var spacer = Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(spacer)
+
+	return row
+
+
+func _style_flat_button(btn: Button) -> void:
+	var style = StyleBoxFlat.new()
+	style.bg_color = Color(0.08, 0.12, 0.2, 0.5)
+	style.set_border_width_all(1)
+	style.border_color = Color(0.15, 0.2, 0.3)
+	style.set_corner_radius_all(4)
+	style.content_margin_left = 8
+	style.content_margin_right = 8
+	style.content_margin_top = 4
+	style.content_margin_bottom = 4
+	btn.add_theme_stylebox_override("normal", style)
+
+	var hover = style.duplicate()
+	hover.bg_color = Color(0.12, 0.16, 0.25, 0.7)
+	btn.add_theme_stylebox_override("hover", hover)
+	btn.add_theme_stylebox_override("pressed", style)
+
+
+func _style_action_button(btn: Button, color: Color) -> void:
+	var style = StyleBoxFlat.new()
+	style.bg_color = color.darkened(0.4)
+	style.set_border_width_all(1)
+	style.border_color = color.darkened(0.1)
+	style.set_corner_radius_all(4)
+	style.set_content_margin_all(6)
+	btn.add_theme_stylebox_override("normal", style)
+	btn.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	btn.add_theme_font_size_override("font_size", 13)
+
+	var hover = style.duplicate()
+	hover.bg_color = color.darkened(0.2)
+	btn.add_theme_stylebox_override("hover", hover)
+	btn.add_theme_stylebox_override("pressed", style)
+
+
+# ─── Interactions ────────────────────────────────────────────────
+
+func _on_like_pressed(post: Dictionary, btn: Button) -> void:
 	AudioManager.play_ui_click()
-	article.likes += 1
-	label.text = "%d likes" % article.likes
+	SocialFeedManager.toggle_like(post.post_id)
+	var is_liked = post.get("player_liked", false)
+	btn.text = "%d %s" % [post.get("likes", 0), "Liked" if is_liked else "Like"]
+	btn.add_theme_color_override("font_color", COLOR_ACCENT_RED if is_liked else COLOR_TEXT_DIM)
 
 
-func _on_news_article(article: Dictionary) -> void:
-	news_articles.insert(0, {
-		"headline": article.get("headline", "News Update"),
-		"body": article.get("body", ""),
-		"author": article.get("author", "FanZone"),
-		"date": DesktopManager.get_date_string(),
-		"likes": randi_range(20, 150),
-		"comments": randi_range(5, 40)
-	})
+func _on_reply_pressed(post: Dictionary) -> void:
+	AudioManager.play_ui_click()
+	_show_thread_view(post)
 
-	# Keep only recent articles
-	if news_articles.size() > 20:
-		news_articles.resize(20)
 
-	if is_open:
-		_refresh_display()
+# ─── Thread View ─────────────────────────────────────────────────
+
+func _build_thread_view() -> void:
+	if not thread_view:
+		return
+	if thread_scroll:
+		return  # Already built
+
+	thread_view.visible = false
+
+	# Clear any placeholder children
+	for child in thread_view.get_children():
+		child.queue_free()
+
+	# Original post container
+	thread_original_post = VBoxContainer.new()
+	thread_view.add_child(thread_original_post)
+
+	# Separator
+	var sep = HSeparator.new()
+	sep.add_theme_color_override("separator", COLOR_BORDER)
+	thread_view.add_child(sep)
+
+	# Replies label
+	var replies_header = Label.new()
+	replies_header.text = "Replies"
+	replies_header.add_theme_font_size_override("font_size", 14)
+	replies_header.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	thread_view.add_child(replies_header)
+
+	# Scroll for replies
+	thread_scroll = ScrollContainer.new()
+	thread_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	thread_container = VBoxContainer.new()
+	thread_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	thread_container.add_theme_constant_override("separation", 8)
+	thread_scroll.add_child(thread_container)
+	thread_view.add_child(thread_scroll)
+
+	# Reply input area
+	var reply_area = HBoxContainer.new()
+	reply_area.add_theme_constant_override("separation", 8)
+
+	thread_reply_input = TextEdit.new()
+	thread_reply_input.placeholder_text = "Write a reply..."
+	thread_reply_input.custom_minimum_size = Vector2(0, 50)
+	thread_reply_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	thread_reply_input.add_theme_font_size_override("font_size", 13)
+	thread_reply_input.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	var input_style = StyleBoxFlat.new()
+	input_style.bg_color = Color(0.04, 0.06, 0.12)
+	input_style.set_border_width_all(1)
+	input_style.border_color = COLOR_BORDER
+	input_style.set_corner_radius_all(4)
+	input_style.set_content_margin_all(8)
+	thread_reply_input.add_theme_stylebox_override("normal", input_style)
+	thread_reply_input.add_theme_stylebox_override("focus", input_style)
+	reply_area.add_child(thread_reply_input)
+
+	thread_reply_button = Button.new()
+	thread_reply_button.text = "Reply"
+	thread_reply_button.custom_minimum_size = Vector2(70, 50)
+	_style_action_button(thread_reply_button, COLOR_ACCENT_BLUE)
+	thread_reply_button.pressed.connect(_on_thread_reply_submit)
+	reply_area.add_child(thread_reply_button)
+
+	thread_view.add_child(reply_area)
+
+
+func _show_thread_view(post: Dictionary) -> void:
+	current_view = ViewState.THREAD
+	current_thread_post_id = post.post_id
+
+	# Hide feed elements
+	if filter_bar:
+		filter_bar.visible = false
+	if compose_area:
+		compose_area.visible = false
+	scroll_container.visible = false
+
+	# Show thread view
+	thread_view.visible = true
+
+	# Build original post display
+	for child in thread_original_post.get_children():
+		child.queue_free()
+	var original_card = _create_post_card(post)
+	thread_original_post.add_child(original_card)
+
+	# Build replies
+	_refresh_thread_replies(post)
+
+
+func _refresh_thread_replies(post: Dictionary) -> void:
+	for child in thread_container.get_children():
+		child.queue_free()
+
+	var replies = post.get("replies", [])
+	if replies.is_empty():
+		var empty = Label.new()
+		empty.text = "No replies yet. Be the first!"
+		empty.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+		empty.add_theme_font_size_override("font_size", 13)
+		thread_container.add_child(empty)
+		return
+
+	for reply in replies:
+		var card = _create_reply_card(reply)
+		thread_container.add_child(card)
+
+
+func _create_reply_card(reply: Dictionary) -> PanelContainer:
+	var is_player = reply.get("author_id", "") == "player"
+	var accent = COLOR_PLAYER_ACCENT if is_player else COLOR_ACCENT_GREEN
+
+	var panel = PanelContainer.new()
+	var style = StyleBoxFlat.new()
+	style.bg_color = Color(0.05, 0.08, 0.14, 0.8)
+	style.set_border_width_all(1)
+	style.border_color = accent.darkened(0.4)
+	style.set_corner_radius_all(6)
+	style.set_content_margin_all(10)
+	panel.add_theme_stylebox_override("panel", style)
+
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 4)
+
+	# Author
+	var author_row = HBoxContainer.new()
+	author_row.add_theme_constant_override("separation", 6)
+	var name_label = Label.new()
+	name_label.text = reply.get("author_name", "Unknown")
+	name_label.add_theme_font_size_override("font_size", 13)
+	name_label.add_theme_color_override("font_color", accent if is_player else COLOR_TEXT_PRIMARY)
+	author_row.add_child(name_label)
+	var handle = Label.new()
+	handle.text = reply.get("author_handle", "")
+	handle.add_theme_font_size_override("font_size", 11)
+	handle.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	author_row.add_child(handle)
+	vbox.add_child(author_row)
+
+	# Content
+	var content = Label.new()
+	content.text = reply.get("content", "")
+	content.add_theme_font_size_override("font_size", 13)
+	content.add_theme_color_override("font_color", COLOR_TEXT_SECONDARY)
+	content.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	vbox.add_child(content)
+
+	panel.add_child(vbox)
+	return panel
+
+
+func _on_thread_reply_submit() -> void:
+	var text = thread_reply_input.text.strip_edges()
+	if text.is_empty() or current_thread_post_id == "":
+		return
+
+	AudioManager.play_ui_click()
+	SocialFeedManager.add_player_reply(current_thread_post_id, text)
+	thread_reply_input.text = ""
+
+
+func _show_feed_view() -> void:
+	current_view = ViewState.FEED
+	current_thread_post_id = ""
+
+	# Show feed elements
+	if filter_bar:
+		filter_bar.visible = true
+	if compose_area:
+		compose_area.visible = true
+	scroll_container.visible = true
+
+	# Hide thread
+	thread_view.visible = false
+
+	_refresh_feed()
+
+
+# ─── Signal Handlers ─────────────────────────────────────────────
+
+func _on_post_added(_post: Dictionary) -> void:
+	if not is_open:
+		return
+
+	if current_view == ViewState.FEED:
+		_refresh_feed()
+
+
+func _on_reply_added(parent_post_id: String, _reply: Dictionary) -> void:
+	if not is_open:
+		return
+
+	if current_view == ViewState.THREAD and current_thread_post_id == parent_post_id:
+		var post = SocialFeedManager.get_post_by_id(parent_post_id)
+		if not post.is_empty():
+			_refresh_thread_replies(post)
+
+
+func _on_feed_refreshed() -> void:
+	if is_open and current_view == ViewState.FEED:
+		_refresh_feed()

--- a/scripts/dashboard/panels/panel_social.gd
+++ b/scripts/dashboard/panels/panel_social.gd
@@ -26,6 +26,8 @@ var thread_original_post: VBoxContainer
 
 # Filter buttons for highlighting
 var filter_buttons: Dictionary = {}
+var followers_pill: PanelContainer
+var followers_label: Label
 
 # Colors
 const COLOR_BG_CARD := Color(0.06, 0.1, 0.18, 0.9)
@@ -51,8 +53,10 @@ func _on_panel_ready() -> void:
 
 func _on_panel_opened() -> void:
 	_connect_feed_signals()
+	_connect_career_signals()
 	SocialFeedManager.ensure_welcome_post()
 	_build_filter_bar()
+	_refresh_followers_display()
 	_build_compose_area()
 	_build_thread_view()
 	_refresh_feed()
@@ -60,6 +64,7 @@ func _on_panel_opened() -> void:
 
 func _on_panel_closing() -> void:
 	_disconnect_feed_signals()
+	_disconnect_career_signals()
 
 
 func _connect_feed_signals() -> void:
@@ -78,6 +83,18 @@ func _disconnect_feed_signals() -> void:
 		SocialFeedManager.reply_added.disconnect(_on_reply_added)
 	if SocialFeedManager.feed_refreshed.is_connected(_on_feed_refreshed):
 		SocialFeedManager.feed_refreshed.disconnect(_on_feed_refreshed)
+
+
+func _connect_career_signals() -> void:
+	if CareerManager and CareerManager.has_signal("fan_popularity_changed"):
+		if not CareerManager.fan_popularity_changed.is_connected(_on_fan_popularity_changed):
+			CareerManager.fan_popularity_changed.connect(_on_fan_popularity_changed)
+
+
+func _disconnect_career_signals() -> void:
+	if CareerManager and CareerManager.has_signal("fan_popularity_changed"):
+		if CareerManager.fan_popularity_changed.is_connected(_on_fan_popularity_changed):
+			CareerManager.fan_popularity_changed.disconnect(_on_fan_popularity_changed)
 
 
 # ─── Input Handling ──────────────────────────────────────────────
@@ -129,6 +146,31 @@ func _build_filter_bar() -> void:
 	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	filter_bar.add_child(spacer)
 
+	# Followers pill
+	followers_pill = PanelContainer.new()
+	followers_pill.custom_minimum_size = Vector2(160, 32)
+	var pill_style = StyleBoxFlat.new()
+	pill_style.bg_color = Color(0.06, 0.14, 0.22, 0.95)
+	pill_style.border_color = COLOR_ACCENT_GREEN.darkened(0.25)
+	pill_style.set_border_width_all(1)
+	pill_style.set_corner_radius_all(16)
+	followers_pill.add_theme_stylebox_override("panel", pill_style)
+
+	var pill_margin = MarginContainer.new()
+	pill_margin.add_theme_constant_override("margin_left", 10)
+	pill_margin.add_theme_constant_override("margin_right", 10)
+	pill_margin.add_theme_constant_override("margin_top", 4)
+	pill_margin.add_theme_constant_override("margin_bottom", 4)
+
+	followers_label = Label.new()
+	followers_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	followers_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	followers_label.add_theme_font_size_override("font_size", 12)
+	followers_label.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY)
+	pill_margin.add_child(followers_label)
+	followers_pill.add_child(pill_margin)
+	filter_bar.add_child(followers_pill)
+
 
 func _style_filter_button(btn: Button, active: bool) -> void:
 	var style = StyleBoxFlat.new()
@@ -157,6 +199,21 @@ func _on_filter_pressed(filter_id: String) -> void:
 	for fid in filter_buttons:
 		_style_filter_button(filter_buttons[fid], fid == current_filter)
 	_refresh_feed()
+
+
+func _refresh_followers_display() -> void:
+	if not followers_label:
+		return
+	var followers = CareerManager.fan_popularity if CareerManager else 0
+	followers_label.text = "Followers: %s" % _format_followers(followers)
+
+
+func _format_followers(count: int) -> String:
+	if count >= 1000000:
+		return "%.1fM" % (float(count) / 1000000.0)
+	if count >= 1000:
+		return "%.1fK" % (float(count) / 1000.0)
+	return str(count)
 
 
 # ─── Compose Area ────────────────────────────────────────────────
@@ -892,3 +949,7 @@ func _on_reply_added(parent_post_id: String, _reply: Dictionary) -> void:
 func _on_feed_refreshed() -> void:
 	if is_open and current_view == ViewState.FEED:
 		_refresh_feed()
+
+
+func _on_fan_popularity_changed(_new_total: int, _delta: int, _outcome: String) -> void:
+	_refresh_followers_display()

--- a/scripts/dashboard/panels/panel_social_v2.gd
+++ b/scripts/dashboard/panels/panel_social_v2.gd
@@ -1,0 +1,187 @@
+extends PanelSocial
+class_name PanelSocialV2
+## PanelSocialV2 - FanZone V2 panel with hybrid ranking and ranking reason labels
+
+var current_sort_mode: String = "top"
+var sort_bar: HBoxContainer
+var sort_buttons: Dictionary = {}
+
+const COLOR_SORT_ACTIVE := Color(0.2, 0.5, 0.9)
+const COLOR_SORT_INACTIVE := Color(0.15, 0.2, 0.3)
+
+
+func _on_panel_ready() -> void:
+	panel_title = "FanZone"
+	if title_label:
+		title_label.text = panel_title
+
+
+func _on_panel_opened() -> void:
+	_connect_feed_signals()
+	SocialFeedManager.ensure_welcome_post_v2()
+	_build_filter_bar()
+	_build_sort_bar()
+	_build_compose_area()
+	_build_thread_view()
+	_refresh_feed()
+
+
+func _on_panel_closing() -> void:
+	_disconnect_feed_signals()
+
+
+func _connect_feed_signals() -> void:
+	if not SocialFeedManager.post_added_v2.is_connected(_on_post_added):
+		SocialFeedManager.post_added_v2.connect(_on_post_added)
+	if not SocialFeedManager.reply_added_v2.is_connected(_on_reply_added):
+		SocialFeedManager.reply_added_v2.connect(_on_reply_added)
+	if not SocialFeedManager.feed_refreshed_v2.is_connected(_on_feed_refreshed):
+		SocialFeedManager.feed_refreshed_v2.connect(_on_feed_refreshed)
+
+
+func _disconnect_feed_signals() -> void:
+	if SocialFeedManager.post_added_v2.is_connected(_on_post_added):
+		SocialFeedManager.post_added_v2.disconnect(_on_post_added)
+	if SocialFeedManager.reply_added_v2.is_connected(_on_reply_added):
+		SocialFeedManager.reply_added_v2.disconnect(_on_reply_added)
+	if SocialFeedManager.feed_refreshed_v2.is_connected(_on_feed_refreshed):
+		SocialFeedManager.feed_refreshed_v2.disconnect(_on_feed_refreshed)
+
+
+func _build_sort_bar() -> void:
+	if sort_bar:
+		return
+
+	sort_bar = HBoxContainer.new()
+	sort_bar.add_theme_constant_override("separation", 8)
+
+	var sort_label = Label.new()
+	sort_label.text = "Sort:"
+	sort_label.add_theme_font_size_override("font_size", 12)
+	sort_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+	sort_bar.add_child(sort_label)
+
+	var sort_options = [
+		{"id": "top", "label": "Top"},
+		{"id": "latest", "label": "Latest"}
+	]
+
+	for opt in sort_options:
+		var btn = Button.new()
+		btn.text = opt.label
+		btn.custom_minimum_size = Vector2(72, 28)
+		btn.add_theme_font_size_override("font_size", 12)
+		btn.pressed.connect(_on_sort_pressed.bind(opt.id))
+		_style_sort_button(btn, opt.id == current_sort_mode)
+		sort_buttons[opt.id] = btn
+		sort_bar.add_child(btn)
+
+	var spacer = Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	sort_bar.add_child(spacer)
+
+	var insert_idx = 1 if filter_bar else 0
+	main_content.add_child(sort_bar)
+	main_content.move_child(sort_bar, insert_idx)
+
+
+func _style_sort_button(btn: Button, active: bool) -> void:
+	var style = StyleBoxFlat.new()
+	style.bg_color = COLOR_SORT_ACTIVE if active else COLOR_SORT_INACTIVE
+	style.set_border_width_all(1)
+	style.border_color = COLOR_ACCENT_BLUE if active else COLOR_BORDER
+	style.set_corner_radius_all(4)
+	style.set_content_margin_all(4)
+	btn.add_theme_stylebox_override("normal", style)
+	btn.add_theme_stylebox_override("pressed", style)
+
+	var hover = style.duplicate()
+	hover.bg_color = hover.bg_color.lightened(0.08)
+	btn.add_theme_stylebox_override("hover", hover)
+
+	btn.add_theme_color_override("font_color", COLOR_TEXT_PRIMARY if active else COLOR_TEXT_DIM)
+
+
+func _on_sort_pressed(sort_mode: String) -> void:
+	if sort_mode == current_sort_mode:
+		return
+	AudioManager.play_ui_click()
+	current_sort_mode = sort_mode
+	for key in sort_buttons:
+		_style_sort_button(sort_buttons[key], key == current_sort_mode)
+	_refresh_feed()
+
+
+func _on_compose_submit() -> void:
+	var text = compose_input.text.strip_edges()
+	if text.is_empty():
+		return
+
+	AudioManager.play_ui_click()
+	SocialFeedManager.create_player_post_v2(text)
+	compose_input.text = ""
+
+
+func _refresh_feed() -> void:
+	if not feed_container:
+		return
+
+	for child in feed_container.get_children():
+		child.queue_free()
+
+	var posts = SocialFeedManager.get_feed_v2(current_filter, current_sort_mode)
+
+	if posts.is_empty():
+		var empty_label = Label.new()
+		empty_label.text = "No posts yet. Play matches to generate news!"
+		empty_label.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+		feed_container.add_child(empty_label)
+		return
+
+	for i in range(posts.size()):
+		var post = posts[i]
+		var card = _create_post_card(post)
+
+		if current_sort_mode == "top" and i < 3:
+			var wrapper = VBoxContainer.new()
+			wrapper.add_theme_constant_override("separation", 4)
+			var why = Label.new()
+			why.text = "Why this is high: %s" % post.get("ranking_reason", "High relevance")
+			why.add_theme_font_size_override("font_size", 11)
+			why.add_theme_color_override("font_color", COLOR_TEXT_DIM)
+			wrapper.add_child(why)
+			wrapper.add_child(card)
+			feed_container.add_child(wrapper)
+		else:
+			feed_container.add_child(card)
+
+
+func _on_like_pressed(post: Dictionary, btn: Button) -> void:
+	AudioManager.play_ui_click()
+	SocialFeedManager.toggle_like_v2(post.post_id)
+	var updated = SocialFeedManager.get_post_by_id_v2(post.post_id)
+	if updated.is_empty():
+		return
+	var is_liked = updated.get("player_liked", false)
+	btn.text = "%d %s" % [updated.get("likes", 0), "Liked" if is_liked else "Like"]
+	btn.add_theme_color_override("font_color", COLOR_ACCENT_RED if is_liked else COLOR_TEXT_DIM)
+
+
+func _on_thread_reply_submit() -> void:
+	var text = thread_reply_input.text.strip_edges()
+	if text.is_empty() or current_thread_post_id == "":
+		return
+
+	AudioManager.play_ui_click()
+	SocialFeedManager.add_player_reply_v2(current_thread_post_id, text)
+	thread_reply_input.text = ""
+
+
+func _on_reply_added(parent_post_id: String, _reply: Dictionary) -> void:
+	if not is_open:
+		return
+
+	if current_view == ViewState.THREAD and current_thread_post_id == parent_post_id:
+		var post = SocialFeedManager.get_post_by_id_v2(parent_post_id)
+		if not post.is_empty():
+			_refresh_thread_replies(post)

--- a/scripts/dashboard/panels/panel_training.gd
+++ b/scripts/dashboard/panels/panel_training.gd
@@ -293,6 +293,13 @@ func _on_train_pressed(training: Dictionary) -> void:
 		player.stamina_current -= training.stamina_cost
 		player.add_stat_xp(training.stat, training.xp_gain)
 		player.add_xp(training.xp_gain)
+		_apply_training_injuries({
+			"training_type": training.id,
+			"attempts": TrainingConstants.ATTEMPTS_PER_SESSION,
+			"accuracy": 1.0,
+			"player_stamina": player.stamina_current + training.stamina_cost,
+			"stamina_cost": training.stamina_cost
+		})
 
 		if status_label:
 			status_label.text = "Completed %s training! %s +XP" % [training.name, training.stat]
@@ -370,5 +377,40 @@ func _on_simulate_pressed(training: Dictionary, best_score: int, attempts: int) 
 		"training"
 	)
 
+	var stamina_after = player.stamina_current
+	var accuracy = float(best_score) / float(maxi(attempts, 1))
+	var stamina_before = stamina_after + rewards.stamina_cost
+	_apply_training_injuries({
+		"training_type": training.id,
+		"attempts": attempts,
+		"accuracy": accuracy,
+		"player_stamina": stamina_before,
+		"stamina_cost": rewards.stamina_cost
+	})
+
 	_refresh_display()
 	_build_training_options()
+
+
+func _apply_training_injuries(training_context: Dictionary) -> void:
+	var injuries = InjurySystem.process_training_injuries(GameManager.current_team, training_context)
+	if injuries.is_empty():
+		return
+
+	for injury in injuries:
+		var player_name = injury.get("player_name", "Player")
+		var description = injury.get("description", "injury")
+		var matches_out = int(injury.get("matches_out", 0))
+		var severity = injury.get("type", "minor")
+		var injury_type = injury.get("injury_type", "")
+		var severity_text = InjurySystem.get_severity_text(severity)
+		var match_suffix = "es" if matches_out != 1 else ""
+		var match_out_text = " - %d match%s out" % [matches_out, match_suffix] if matches_out > 0 else ""
+		var detail = description if injury_type == "" else "%s (%s)" % [description, injury_type]
+
+		DesktopManager.show_notification(
+			"Injury Report",
+			"%s suffered a %s (%s)%s." % [player_name, severity_text, detail, match_out_text],
+			"",
+			"training"
+		)

--- a/scripts/data/league_data.gd
+++ b/scripts/data/league_data.gd
@@ -82,24 +82,59 @@ func _generate_fixtures() -> void:
 		return
 
 	var match_id_counter = 0
-	var matchday = 1
-
-	# First half of season (each team plays every other team once)
+	var team_indices: Array = []
 	for i in range(num_teams):
-		for j in range(i + 1, num_teams):
+		team_indices.append(i)
+
+	# Add a bye slot for odd number of teams
+	if num_teams % 2 == 1:
+		team_indices.append(-1)
+
+	var total_slots = team_indices.size()
+	var rounds = total_slots - 1
+	var matches_per_round = int(total_slots / 2)
+	var rotation: Array = team_indices.duplicate()
+
+	# First half of season (one match per team per matchday)
+	for round_index in range(rounds):
+		var matchday = round_index + 1
+		var swap_home_away = round_index % 2 == 1
+
+		for match_index in range(matches_per_round):
+			var home_index = rotation[match_index]
+			var away_index = rotation[total_slots - 1 - match_index]
+
+			if home_index == -1 or away_index == -1:
+				continue
+
+			if swap_home_away:
+				var temp = home_index
+				home_index = away_index
+				away_index = temp
+
+			var home_team = teams[home_index]
+			var away_team = teams[away_index]
+
 			fixtures.append({
 				"match_id": "match_%d_%d" % [id.hash(), match_id_counter],
 				"matchday": matchday,
-				"home_id": teams[i].id,
-				"away_id": teams[j].id,
-				"home_team_name": teams[i].name,
-				"away_team_name": teams[j].name,
+				"home_id": home_team.id,
+				"away_id": away_team.id,
+				"home_team_name": home_team.name,
+				"away_team_name": away_team.name,
 				"played": false,
 				"home_score": 0,
 				"away_score": 0
 			})
 			match_id_counter += 1
-			matchday = (matchday % (num_teams - 1)) + 1
+
+		# Rotate teams (keep the first team fixed)
+		var fixed = rotation[0]
+		var new_rotation: Array = [fixed]
+		new_rotation.append(rotation[total_slots - 1])
+		for slot_index in range(1, total_slots - 1):
+			new_rotation.append(rotation[slot_index])
+		rotation = new_rotation
 
 	# Second half of season (reverse fixtures)
 	var first_half_count = fixtures.size()
@@ -107,7 +142,7 @@ func _generate_fixtures() -> void:
 		var original = fixtures[i]
 		fixtures.append({
 			"match_id": "match_%d_%d" % [id.hash(), match_id_counter],
-			"matchday": matchday + original.matchday,
+			"matchday": rounds + original.matchday,
 			"home_id": original.away_id,
 			"away_id": original.home_id,
 			"home_team_name": original.away_team_name,

--- a/scripts/data/team_data.gd
+++ b/scripts/data/team_data.gd
@@ -304,7 +304,8 @@ func get_injured_players() -> Array[Dictionary]:
 			var injury = npc.get("injury", {})
 			injured.append({
 				"player": player,
-				"injury_type": injury.get("type", ""),
+				"injury_type": injury.get("injury_type", injury.get("type", "")),
+				"injury_severity": injury.get("type", ""),
 				"matches_remaining": injury.get("matches_remaining", 0),
 				"description": injury.get("description", "")
 			})

--- a/scripts/data/team_data.gd
+++ b/scripts/data/team_data.gd
@@ -28,6 +28,14 @@ class_name TeamData
 # Prefecture for stable ID generation
 var _prefecture: String = ""
 
+const MINOR_INJURY_STAT_PENALTIES: Dictionary = {
+	"muscle_tightness": {"STA": 6, "SPD": 4, "TEC": 2},
+	"light_bruising": {"PHY": 5, "DEF": 2, "MEN": 2},
+	"ankle_niggle": {"SPD": 6, "TEC": 4, "PAS": 2},
+	"minor_cramp": {"STA": 7, "SPD": 3, "PHY": 2},
+	"_default": {"STA": 4, "SPD": 2, "MEN": 1}
+}
+
 
 func _init() -> void:
 	# Default to random ID; will be overwritten by set_stable_id() when name/prefecture are known
@@ -246,8 +254,8 @@ func get_player_by_position(pos: String) -> Dictionary:
 
 
 func get_starting_eleven() -> Array[Dictionary]:
-	# Returns the best 11 available players (including user's player)
-	# Filters out injured and graduated players
+	# Returns the best 11 match-eligible players (including user's player)
+	# Minor injuries can play through with stat penalties.
 	var eleven: Array[Dictionary] = []
 
 	# Add user's player
@@ -264,20 +272,8 @@ func get_starting_eleven() -> Array[Dictionary]:
 	# Filter to only available players (not injured or graduated)
 	var available_players: Array[Dictionary] = []
 	for player in players:
-		var player_id = player.get("id", "")
-		if player_id == "":
-			available_players.append(player)
-			continue
-
-		# Check NPC status in registry
-		if NpcRegistry.has_npc(player_id):
-			var npc = NpcRegistry.get_npc(player_id)
-			var status = npc.get("status", "active")
-			if status == "active":
-				available_players.append(player)
-		else:
-			# Unknown NPCs are assumed available
-			available_players.append(player)
+		if is_player_available_for_match(player):
+			available_players.append(get_match_ready_player_record(player))
 
 	# Sort by overall rating
 	available_players.sort_custom(func(a, b): return a.overall > b.overall)
@@ -288,6 +284,84 @@ func get_starting_eleven() -> Array[Dictionary]:
 		eleven.append(player)
 
 	return eleven
+
+
+func is_player_available_for_match(player: Dictionary) -> bool:
+	var player_id = player.get("id", "")
+	if player_id == "":
+		return true
+
+	if not NpcRegistry.has_npc(player_id):
+		return true  # Unknown NPCs are assumed available
+
+	return NpcRegistry.is_npc_match_eligible(player_id)
+
+
+func get_match_ready_player_record(player: Dictionary) -> Dictionary:
+	var player_id = player.get("id", "")
+	if player_id == "":
+		return player
+	if not NpcRegistry.has_npc(player_id):
+		return player
+
+	var npc = NpcRegistry.get_npc(player_id)
+	var status = npc.get("status", "active")
+	if status != "injured":
+		return player
+
+	var injury = npc.get("injury", {})
+	var severity = injury.get("type", "")
+	var matches_remaining = int(injury.get("matches_remaining", 0))
+	if severity == "minor" and matches_remaining > 0:
+		return _apply_minor_injury_penalty(player, injury)
+
+	return player
+
+
+func _apply_minor_injury_penalty(player: Dictionary, injury: Dictionary) -> Dictionary:
+	var adjusted = player.duplicate(true)
+	var injury_type = str(injury.get("injury_type", ""))
+	var penalties: Dictionary = MINOR_INJURY_STAT_PENALTIES.get(
+		injury_type,
+		MINOR_INJURY_STAT_PENALTIES["_default"]
+	)
+	var penalty_scale = _minor_injury_penalty_scale(injury)
+
+	var stats: Dictionary = adjusted.get("stats", {}).duplicate(true)
+	if stats.is_empty():
+		var overall_penalty = maxi(1, roundi(4.0 * penalty_scale))
+		adjusted["overall"] = maxi(int(adjusted.get("overall", 50)) - overall_penalty, 1)
+	else:
+		for stat_key in penalties:
+			if stats.has(stat_key):
+				var base_penalty = int(penalties[stat_key])
+				var scaled_penalty = maxi(1, roundi(float(base_penalty) * penalty_scale))
+				stats[stat_key] = clampi(int(stats[stat_key]) - scaled_penalty, 1, 99)
+
+		adjusted["stats"] = stats
+		adjusted["overall"] = StatSystem.calculate_overall(stats, adjusted.get("position", "CM"))
+
+	adjusted["playing_through_injury"] = true
+	adjusted["injury_severity"] = "minor"
+	adjusted["injury_type"] = injury_type
+	adjusted["injury_matches_remaining"] = int(injury.get("matches_remaining", 0))
+	adjusted["injury_penalty_scale"] = penalty_scale
+	return adjusted
+
+
+func _minor_injury_penalty_scale(injury: Dictionary) -> float:
+	var matches_remaining = maxi(int(injury.get("matches_remaining", 0)), 0)
+	if matches_remaining <= 0:
+		return 0.0
+
+	var matches_total = maxi(int(injury.get("matches_total", matches_remaining)), 1)
+	if matches_total <= 1:
+		return 1.0
+
+	var numerator = float(matches_remaining - 1)
+	var denominator = float(maxi(matches_total - 1, 1))
+	var progress = clampf(numerator / denominator, 0.0, 1.0)
+	return lerpf(0.55, 1.0, progress)
 
 
 func get_injured_players() -> Array[Dictionary]:

--- a/scripts/desktop/apps/app_training.gd
+++ b/scripts/desktop/apps/app_training.gd
@@ -251,9 +251,17 @@ func _on_train_pressed(training: Dictionary) -> void:
 			return
 
 		# Apply training
+		var stamina_before = player.stamina_current
 		player.stamina_current -= training.stamina_cost
 		player.add_stat_xp(training.stat, training.xp_gain)
 		player.add_xp(training.xp_gain)
+		_apply_training_injuries({
+			"training_type": training.id,
+			"attempts": TrainingConstants.ATTEMPTS_PER_SESSION,
+			"accuracy": 1.0,
+			"player_stamina": stamina_before,
+			"stamina_cost": training.stamina_cost
+		})
 
 		status_label.text = "Completed %s training! %s +XP" % [training.name, training.stat]
 		DesktopManager.advance_time(2)
@@ -354,5 +362,40 @@ func _on_simulate_pressed(training: Dictionary, best_score: int, attempts: int) 
 		"training"
 	)
 
+	var stamina_after = player.stamina_current
+	var accuracy = float(best_score) / float(maxi(attempts, 1))
+	var stamina_before = stamina_after + rewards.stamina_cost
+	_apply_training_injuries({
+		"training_type": training.id,
+		"attempts": attempts,
+		"accuracy": accuracy,
+		"player_stamina": stamina_before,
+		"stamina_cost": rewards.stamina_cost
+	})
+
 	_refresh_display()
 	_build_training_options()
+
+
+func _apply_training_injuries(training_context: Dictionary) -> void:
+	var injuries = InjurySystem.process_training_injuries(GameManager.current_team, training_context)
+	if injuries.is_empty():
+		return
+
+	for injury in injuries:
+		var player_name = injury.get("player_name", "Player")
+		var description = injury.get("description", "injury")
+		var matches_out = int(injury.get("matches_out", 0))
+		var severity = injury.get("type", "minor")
+		var injury_type = injury.get("injury_type", "")
+		var severity_text = InjurySystem.get_severity_text(severity)
+		var match_suffix = "es" if matches_out != 1 else ""
+		var match_out_text = " - %d match%s out" % [matches_out, match_suffix] if matches_out > 0 else ""
+		var detail = description if injury_type == "" else "%s (%s)" % [description, injury_type]
+
+		DesktopManager.show_notification(
+			"Injury Report",
+			"%s suffered a %s (%s)%s." % [player_name, severity_text, detail, match_out_text],
+			"",
+			"training"
+		)

--- a/scripts/desktop/desktop_manager.gd
+++ b/scripts/desktop/desktop_manager.gd
@@ -371,6 +371,8 @@ func open_panel(panel_id: String, parent: Node) -> Control:
 		close_current_panel()
 
 	var panel_path = panel_scenes.get(panel_id, "")
+	if panel_id == "social" and SocialFeedManager and SocialFeedManager.is_v2_enabled():
+		panel_path = "res://scenes/dashboard/panels/panel_social_v2.tscn"
 	if panel_path.is_empty():
 		push_error("Unknown panel: " + panel_id)
 		return null

--- a/scripts/match/post_match.gd
+++ b/scripts/match/post_match.gd
@@ -483,75 +483,9 @@ func _update_season_standings() -> void:
 
 
 func _roll_for_injuries() -> void:
-	"""Roll for injuries after the match and apply them."""
-	if not GameManager.current_team:
-		if match_result:
-			match_result["injury_events"] = []
-		return
-
-	# Determine match intensity based on current competition
-	var match_type = SeasonManager.get_match_type()
-	var competition_stage = ""
-	var tournament = SeasonManager.get_current_tournament()
-	if tournament:
-		competition_stage = TournamentData.Stage.keys()[tournament.current_stage].to_lower()
-
-	var intensity = InjurySystem.get_match_intensity(match_type, competition_stage)
-
-	# Roll for injuries on the player's team
-	var injuries = InjurySystem.roll_for_injuries(GameManager.current_team, intensity)
-
-	# Store injury events for timeline display
-	var injury_events: Array[Dictionary] = []
-
-	if injuries.is_empty():
-		match_result["injury_events"] = injury_events
-		return
-
-	# Apply injuries to NPC registry
-	InjurySystem.apply_injuries(injuries)
-
-	# Display injury notifications
-	for injury in injuries:
-		var npc_id = injury.get("npc_id", "")
-		var npc = NpcRegistry.get_npc(npc_id)
-		var player_name = npc.get("name", "Unknown Player")
-		var description = injury.get("description", "injury")
-		var matches_out = injury.get("matches_out", 1)
-		var injury_type = injury.get("type", "minor")
-
-		# Record severe injuries as career events for persona evolution tracking
-		if injury_type == "severe":
-			NpcRegistry.record_career_event(npc_id, "severe_injury")
-
-		# Show notification
-		var severity_text = InjurySystem.get_severity_text(injury_type)
-		DesktopManager.show_notification(
-			"Injury Report",
-			"%s suffered a %s (%s). Out for %d match%s." % [
-				player_name,
-				description,
-				severity_text,
-				matches_out,
-				"es" if matches_out > 1 else ""
-			],
-			"", ""
-		)
-
-		# Add to milestones display
-		_add_injury_display(player_name, description, injury_type)
-
-		injury_events.append({
-			"minute": 90,
-			"team_id": GameManager.current_team.id,
-			"team_name": GameManager.current_team.name,
-			"player_name": player_name,
-			"description": description,
-			"matches_out": matches_out,
-			"injury_type": injury_type
-		})
-
-	match_result["injury_events"] = injury_events
+	"""No injury rolls in post-match flow. Training is now the only source."""
+	if match_result:
+		match_result["injury_events"] = []
 
 
 func _add_injury_display(player_name: String, description: String, injury_type: String) -> void:

--- a/scripts/match/post_match.gd
+++ b/scripts/match/post_match.gd
@@ -16,6 +16,8 @@ class_name PostMatchScreen
 @onready var dribbles_label: Label = $MainContainer/PerformanceSection/StatsGrid/DribblesValue
 
 @onready var xp_gained_label: Label = $MainContainer/RewardsSection/XPGained
+@onready var reputation_label: Label = $MainContainer/RewardsSection/ReputationLabel
+@onready var reputation_breakdown_label: Label = $MainContainer/RewardsSection/ReputationBreakdown
 @onready var milestones_container: VBoxContainer = $MainContainer/RewardsSection/MilestonesContainer
 
 @onready var event_list: VBoxContainer = $MainContainer/EventSection/EventScroll/EventList
@@ -78,6 +80,7 @@ func _display_result() -> void:
 	# Calculate and display XP gained
 	var xp_gained = _calculate_xp_display()
 	xp_gained_label.text = "+%d XP" % xp_gained
+	_display_reputation()
 
 	# Man of the Match
 	if match_result.get("man_of_match", false):
@@ -422,6 +425,51 @@ func _generate_match_narrative() -> String:
 		lines.append("Room for improvement, but experience gained.")
 
 	return "\n".join(lines)
+
+
+func _display_reputation() -> void:
+	if not reputation_label:
+		return
+
+	var rep_before = int(match_result.get("reputation_before", CareerManager.reputation))
+	var rep_after = int(match_result.get("reputation_after", CareerManager.reputation))
+	var rep_delta = int(match_result.get("reputation_delta", rep_after - rep_before))
+	var tier_name = str(match_result.get("reputation_tier", "Unknown"))
+
+	var delta_prefix = "+" if rep_delta > 0 else ""
+	reputation_label.text = "Reputation: %s%d -> %d (%s)" % [delta_prefix, rep_delta, rep_after, tier_name]
+	if rep_delta > 0:
+		reputation_label.add_theme_color_override("font_color", Color(0.45, 0.9, 0.55))
+	elif rep_delta < 0:
+		reputation_label.add_theme_color_override("font_color", Color(0.95, 0.45, 0.45))
+	else:
+		reputation_label.add_theme_color_override("font_color", Color(0.7, 0.78, 0.86))
+
+	if not reputation_breakdown_label:
+		return
+	var breakdown = match_result.get("reputation_breakdown", [])
+	reputation_breakdown_label.text = _format_reputation_breakdown(breakdown)
+
+
+func _format_reputation_breakdown(breakdown: Array) -> String:
+	if breakdown.is_empty():
+		return "No reputation changes."
+
+	var parts: Array[String] = []
+	for entry in breakdown:
+		var source = str(entry.get("source", "change"))
+		var delta = int(entry.get("delta", 0))
+		if delta == 0:
+			continue
+		var label = source.replace("_", " ").capitalize()
+		var prefix = "+" if delta > 0 else ""
+		parts.append("%s %s%d" % [label, prefix, delta])
+		if parts.size() >= 4:
+			break
+
+	if parts.is_empty():
+		return "No significant modifiers."
+	return "Breakdown: " + " | ".join(parts)
 
 
 func _update_season_standings() -> void:

--- a/scripts/match/tactical/action_resolver.gd
+++ b/scripts/match/tactical/action_resolver.gd
@@ -249,13 +249,13 @@ static func execute_shot(shooter: PlayerUnit, goal_hex: Vector2i,
 
 	var save_roll = StatSystem.roll_action_success(gk_stat, 0, save_difficulty)
 
-	if match_data:
-		match_data.record_event("shot", {
-			"is_player": shooter.is_player_controlled,
-			"on_target": true
-		})
-
 	if save_roll.success:
+		if match_data:
+			match_data.record_event("shot", {
+				"is_player": shooter.is_player_controlled,
+				"on_target": true,
+				"saved": true
+			})
 		return {
 			"success": false,
 			"reason": "saved",

--- a/scripts/match/tactical/match_controller.gd
+++ b/scripts/match/tactical/match_controller.gd
@@ -203,7 +203,8 @@ func _team_roster_data(is_home: bool) -> Array[Dictionary]:
 		return roster
 
 	for player in team.players:
-		roster.append(player)
+		if team.is_player_available_for_match(player):
+			roster.append(team.get_match_ready_player_record(player))
 
 	# Ensure player character data is present in home roster
 	if is_home and GameManager.player_data:
@@ -240,8 +241,7 @@ func _is_active_player_record(data: Dictionary) -> bool:
 		return true
 	if not NpcRegistry.has_npc(player_id):
 		return true
-	var npc = NpcRegistry.get_npc(player_id)
-	return npc.get("status", "active") == "active"
+	return NpcRegistry.is_npc_match_eligible(player_id)
 
 
 func _lineup_for_team(is_home: bool) -> Array[Dictionary]:

--- a/scripts/match/tactical/match_controller.gd
+++ b/scripts/match/tactical/match_controller.gd
@@ -8,6 +8,7 @@ signal score_changed(home: int, away: int)
 signal action_selected(action_type: String)
 signal dribble_move_changed(move_id: String)
 signal match_ended(result: Dictionary)
+signal substitution_executed(is_home_team: bool, out_name: String, in_name: String)
 
 enum TurnPhase {
 	PLAYER,    # Human controls their character
@@ -47,6 +48,7 @@ var last_shooter: PlayerUnit = null  # Track shooter for goal attribution (posse
 const TURNS_PER_HALF: int = 45
 const MINUTES_PER_TURN: int = 1  # 45 turns * 1 minute = 45 min per half = 90 min total
 const INITIATIVE_RANDOM_BONUS: int = 12
+const MAX_SUBSTITUTIONS_PER_SIDE: int = 3  # Per team, per match
 
 # Grid and units
 var hex_grid: TileMapLayer
@@ -54,6 +56,10 @@ var all_units: Array[PlayerUnit] = []
 var home_units: Array[PlayerUnit] = []
 var away_units: Array[PlayerUnit] = []
 var player_unit: PlayerUnit = null
+var home_lineup: Array[Dictionary] = []
+var away_lineup: Array[Dictionary] = []
+var home_substitutions_used: int = 0
+var away_substitutions_used: int = 0
 
 # Ball
 var ball: BallController
@@ -165,6 +171,7 @@ func _spawn_units() -> void:
 
 	# Spawn home team
 	var home_starting = home_team.get_starting_eleven()
+	home_lineup = home_starting.duplicate(true)
 	for i in range(mini(home_starting.size(), home_formation.size())):
 		var player_data = home_starting[i]
 		var formation_pos = home_formation[i]
@@ -178,6 +185,7 @@ func _spawn_units() -> void:
 
 	# Spawn away team
 	var away_starting = away_team.get_starting_eleven()
+	away_lineup = away_starting.duplicate(true)
 	for i in range(mini(away_starting.size(), away_formation.size())):
 		var player_data = away_starting[i]
 		var formation_pos = away_formation[i]
@@ -185,6 +193,161 @@ func _spawn_units() -> void:
 		var unit = _create_unit(player_data, false, formation_pos.hex)
 		away_units.append(unit)
 		all_units.append(unit)
+
+
+func _team_roster_data(is_home: bool) -> Array[Dictionary]:
+	var team = match_data.home_team if is_home else match_data.away_team
+	var roster: Array[Dictionary] = []
+
+	if not team:
+		return roster
+
+	for player in team.players:
+		roster.append(player)
+
+	# Ensure player character data is present in home roster
+	if is_home and GameManager.player_data:
+		var player_exists = false
+		for player in roster:
+			if player.get("id", "") == GameManager.player_data.id:
+				player_exists = true
+				break
+		if not player_exists:
+			roster.append({
+				"id": GameManager.player_data.id,
+				"name": GameManager.player_data.name,
+				"position": GameManager.player_data.position,
+				"stats": GameManager.player_data.stats,
+				"overall": GameManager.player_data.get_overall(),
+				"is_player": true
+			})
+
+	return roster
+
+
+func _player_key(data: Dictionary) -> String:
+	var player_id = data.get("id", "")
+	if player_id != "":
+		return player_id
+	return "%s|%s" % [str(data.get("name", "")), str(data.get("position", ""))]
+
+
+func _is_active_player_record(data: Dictionary) -> bool:
+	var player_id = data.get("id", "")
+	if player_id == "":
+		return true
+	if not NpcRegistry:
+		return true
+	if not NpcRegistry.has_npc(player_id):
+		return true
+	var npc = NpcRegistry.get_npc(player_id)
+	return npc.get("status", "active") == "active"
+
+
+func _lineup_for_team(is_home: bool) -> Array[Dictionary]:
+	return home_lineup if is_home else away_lineup
+
+
+func _substitutions_used(is_home: bool) -> int:
+	return home_substitutions_used if is_home else away_substitutions_used
+
+
+func _inc_substitutions(is_home: bool) -> void:
+	if is_home:
+		home_substitutions_used = min(home_substitutions_used + 1, MAX_SUBSTITUTIONS_PER_SIDE)
+	else:
+		away_substitutions_used = min(away_substitutions_used + 1, MAX_SUBSTITUTIONS_PER_SIDE)
+
+
+func get_substitution_candidates_for_player_team() -> Array[Dictionary]:
+	if not player_unit:
+		return []
+
+	var is_home = player_unit.is_home_team
+	var used_keys: Array[String] = []
+	for entry in _lineup_for_team(is_home):
+		used_keys.append(_player_key(entry))
+
+	var candidates: Array[Dictionary] = []
+	for player_data in _team_roster_data(is_home):
+		var key = _player_key(player_data)
+		if key in used_keys:
+			continue
+		if not _is_active_player_record(player_data):
+			continue
+		candidates.append(player_data)
+
+	return candidates
+
+
+func get_remaining_substitutions() -> int:
+	if not player_unit:
+		return 0
+	return MAX_SUBSTITUTIONS_PER_SIDE - _substitutions_used(player_unit.is_home_team)
+
+
+func can_player_substitute() -> bool:
+	if not player_unit:
+		return false
+	if not match_data:
+		return false
+	if match_phase != MatchPhase.PLAYING:
+		return false
+	if current_phase != TurnPhase.PLAYER:
+		return false
+	if not is_player_turn_active:
+		return false
+	if player_unit.action_points < player_unit.max_action_points:
+		return false
+	if _substitutions_used(player_unit.is_home_team) >= MAX_SUBSTITUTIONS_PER_SIDE:
+		return false
+	if get_substitution_candidates_for_player_team().is_empty():
+		return false
+	return true
+
+
+func perform_substitution() -> bool:
+	if not can_player_substitute():
+		return false
+
+	var is_home = player_unit.is_home_team
+	var outgoing = _pick_outgoing_unit_for_substitution(is_home)
+	if not outgoing:
+		return false
+
+	var candidates = get_substitution_candidates_for_player_team()
+	if candidates.is_empty():
+		return false
+
+	var incoming = _pick_best_substitute_candidate(candidates)
+	return _apply_substitution(outgoing, incoming)
+
+
+func _pick_outgoing_unit_for_substitution(is_home: bool) -> PlayerUnit:
+	var team_units = home_units if is_home else away_units
+	var non_player_lowest: PlayerUnit = null
+	var fallback: PlayerUnit = null
+
+	for unit in team_units:
+		if not unit:
+			continue
+		if fallback == null:
+			fallback = unit
+		if not unit.is_player_controlled and (non_player_lowest == null or unit.overall < non_player_lowest.overall):
+			non_player_lowest = unit
+
+	return non_player_lowest if non_player_lowest else fallback
+
+
+func _pick_best_substitute_candidate(candidates: Array[Dictionary]) -> Dictionary:
+	var best: Dictionary = {}
+	var best_score = -1
+	for player_data in candidates:
+		var score = int(player_data.get("overall", 0))
+		if score > best_score:
+			best_score = score
+			best = player_data
+	return best
 
 
 func _create_unit(data: Dictionary, is_home: bool, hex_pos: Vector2i) -> PlayerUnit:
@@ -531,6 +694,98 @@ func select_action(action: String) -> void:
 	current_action = action
 	action_selected.emit(action)
 	_show_action_range(action)
+
+
+func _find_lineup_entry_index(lineup: Array[Dictionary], unit: PlayerUnit) -> int:
+	var unit_key = _player_key({
+		"id": unit.unit_id,
+		"name": unit.unit_name,
+		"position": unit.position_role
+	})
+	for i in range(lineup.size()):
+		if _player_key(lineup[i]) == unit_key:
+			return i
+	return -1
+
+
+func _replace_unit_in_array_with(container: Array, old_unit: PlayerUnit, new_unit: PlayerUnit) -> bool:
+	var index = container.find(old_unit)
+	if index == -1:
+		return false
+	container[index] = new_unit
+	return true
+
+
+func _apply_substitution(outgoing_unit: PlayerUnit, incoming_data: Dictionary) -> bool:
+	if not outgoing_unit or incoming_data.is_empty():
+		return false
+	if not all_units.has(outgoing_unit):
+		return false
+
+	var is_home = outgoing_unit.is_home_team
+	var team_units = home_units if is_home else away_units
+	var had_ball = outgoing_unit.has_ball
+	var outgoing_name = outgoing_unit.unit_name
+	var outgoing_id = outgoing_unit.unit_id
+	var outgoing_is_player = outgoing_unit.is_player_controlled
+	var spawn_hex = outgoing_unit.hex_position
+	var outgoing_is_current_actor = outgoing_unit == player_unit
+
+	var incoming_unit = _create_unit(incoming_data, is_home, spawn_hex)
+	incoming_unit.reset_turn()
+
+	if not _replace_unit_in_array_with(team_units, outgoing_unit, incoming_unit):
+		incoming_unit.queue_free()
+		return false
+
+	if not _replace_unit_in_array_with(all_units, outgoing_unit, incoming_unit):
+		incoming_unit.queue_free()
+		return false
+
+	var team_lineup = _lineup_for_team(is_home)
+	var lineup_index = _find_lineup_entry_index(team_lineup, outgoing_unit)
+	if lineup_index >= 0:
+		team_lineup[lineup_index] = incoming_data
+	else:
+		team_lineup.append(incoming_data)
+
+	for i in range(initiative_order.size()):
+		if initiative_order[i] == outgoing_unit:
+			initiative_order[i] = incoming_unit
+
+	if outgoing_is_player:
+		player_unit = incoming_unit
+	if outgoing_is_current_actor:
+		current_phase = TurnPhase.PLAYER
+		is_player_turn_active = true
+		selected_unit = incoming_unit
+		_select_unit(incoming_unit)
+	elif selected_unit == outgoing_unit:
+		selected_unit = incoming_unit
+		_select_unit(incoming_unit)
+
+	outgoing_unit.queue_free()
+
+	if had_ball:
+		ball.give_possession(incoming_unit)
+
+	_inc_substitutions(is_home)
+	current_action = ""
+	_clear_highlights()
+
+	substitution_executed.emit(is_home, outgoing_name, str(incoming_data.get("name", "Unknown")))
+
+	if match_data:
+		match_data.record_event("substitution", {
+			"is_player": outgoing_is_player,
+			"outgoing_id": outgoing_id,
+			"outgoing_name": outgoing_name,
+			"incoming_id": incoming_data.get("id", ""),
+			"incoming_name": incoming_data.get("name", "Unknown"),
+			"team": "home" if is_home else "away"
+		})
+
+	return true
 
 
 func end_player_turn() -> void:

--- a/scripts/match/tactical/match_controller.gd
+++ b/scripts/match/tactical/match_controller.gd
@@ -36,6 +36,7 @@ var away_score: int = 0
 var home_goal_events: Array[Dictionary] = []
 var away_goal_events: Array[Dictionary] = []
 var last_passer: PlayerUnit = null  # Track who made the last pass for assist attribution
+var last_shooter: PlayerUnit = null  # Track shooter for goal attribution (possession is cleared during flight)
 
 # Turn settings
 const TURNS_PER_HALF: int = 45
@@ -403,6 +404,7 @@ func _execute_shot(target_hex: Vector2i) -> void:
 	var result = ActionResolver.execute_shot(player_unit, target_hex, goalkeeper, blockers, match_data)
 
 	if result.success:
+		last_shooter = player_unit
 		ball.start_shot(player_unit, target_hex)
 	else:
 		match result.reason:
@@ -771,13 +773,15 @@ func _execute_ai_decision(unit: PlayerUnit, decision: Dictionary) -> void:
 
 		"shoot":
 			if unit.has_ball:
-				var target = decision.get("target")
+				var attacking_right = home_attacks_right if unit.is_home_team else not home_attacks_right
+				var target = decision.get("target", HexUtils.get_goal_hex(attacking_right))
 				var opponents = away_units if unit.is_home_team else home_units
 				var goalkeeper = _find_goalkeeper(opponents)
 				var blockers = _get_units_between(unit.hex_position, target, opponents)
 				var result = ActionResolver.execute_shot(unit, target, goalkeeper, blockers, match_data)
 
 				if result.success:
+					last_shooter = unit
 					ball.start_shot(unit, target)
 				else:
 					if result.reason == "blocked":
@@ -823,8 +827,8 @@ func _on_goal_scored(is_home_goal: bool) -> void:
 	else:
 		home_score += 1
 
-	# Determine scorer (last unit with possession)
-	var scorer = ball.get_possessing_unit()
+	# Possession is cleared while the ball is in flight, so track the shooter explicitly.
+	var scorer = last_shooter if last_shooter else ball.get_possessing_unit()
 
 	# Create goal event for season tracking
 	var goal_event: Dictionary = {}
@@ -854,17 +858,12 @@ func _on_goal_scored(is_home_goal: bool) -> void:
 
 	# Reset last passer after goal
 	last_passer = null
+	last_shooter = null
 
 	# Update match data
 	if match_data:
 		match_data.home_score = home_score
 		match_data.away_score = away_score
-
-		var is_player_goal = scorer and scorer == player_unit
-		var team_scored = not is_home_goal == (player_unit and player_unit.is_home_team)
-
-		if team_scored and is_player_goal:
-			match_data.record_event("goal", {"is_player": true})
 
 	score_changed.emit(home_score, away_score)
 

--- a/scripts/match/tactical/match_controller.gd
+++ b/scripts/match/tactical/match_controller.gd
@@ -32,6 +32,11 @@ var match_minute: int = 0
 var home_score: int = 0
 var away_score: int = 0
 
+# Initiative order (player-level queue for this turn)
+var initiative_order: Array[PlayerUnit] = []
+var initiative_cursor: int = -1
+var is_player_turn_active: bool = false
+
 # Goal tracking for season awards
 var home_goal_events: Array[Dictionary] = []
 var away_goal_events: Array[Dictionary] = []
@@ -41,6 +46,7 @@ var last_shooter: PlayerUnit = null  # Track shooter for goal attribution (posse
 # Turn settings
 const TURNS_PER_HALF: int = 45
 const MINUTES_PER_TURN: int = 1  # 45 turns * 1 minute = 45 min per half = 90 min total
+const INITIATIVE_RANDOM_BONUS: int = 12
 
 # Grid and units
 var hex_grid: TileMapLayer
@@ -528,46 +534,145 @@ func select_action(action: String) -> void:
 
 
 func end_player_turn() -> void:
-	if current_phase != TurnPhase.PLAYER:
+	if not is_player_turn_active:
 		return
 
-	_advance_to_team_phase()
+	is_player_turn_active = false
+	_process_next_initiative_actor()
 
 
 ## Turn management
 func _start_player_turn() -> void:
+	_clear_highlights()
 	current_phase = TurnPhase.PLAYER
 
-	# Reset player AP
-	if player_unit:
-		player_unit.reset_turn()
-		_select_unit(player_unit)
+	# Reset all units for this turn.
+	for unit in all_units:
+		unit.reset_turn()
 
-	turn_changed.emit(current_phase, current_turn)
+	# Build initiative order for this minute and start the queue.
+	_build_initiative_order()
+	initiative_cursor = -1
+	is_player_turn_active = false
+	_process_next_initiative_actor()
 
 
-func _advance_to_team_phase() -> void:
-	_clear_highlights()
+func _process_next_initiative_actor() -> void:
+	var actor: PlayerUnit = _get_next_initiative_actor()
+
+	# All actors completed
+	if not actor:
+		is_player_turn_active = false
+		_end_turn()
+		return
+
+	# Clear any stale player selection/highlights between actor switches.
 	selected_unit = null
+	_clear_highlights()
 	current_action = ""
+	_update_active_player_selection(actor)
 
-	current_phase = TurnPhase.TEAM
+	if actor == player_unit:
+		current_phase = TurnPhase.PLAYER
+		is_player_turn_active = true
+		turn_changed.emit(current_phase, current_turn)
+		_select_unit(actor)
+		return
+
+	current_phase = TurnPhase.TEAM if _is_player_team_unit(actor) else TurnPhase.OPPONENT
 	turn_changed.emit(current_phase, current_turn)
 
-	# Process teammate AI
-	await _process_team_ai()
-
-	_advance_to_opponent_phase()
+	await _process_ai_unit_turn(actor)
+	_process_next_initiative_actor()
 
 
-func _advance_to_opponent_phase() -> void:
-	current_phase = TurnPhase.OPPONENT
-	turn_changed.emit(current_phase, current_turn)
+func _build_initiative_order() -> void:
+	var initiative_entries: Array[Dictionary] = []
 
-	# Process opponent AI
-	await _process_opponent_ai()
+	for unit in all_units:
+		if unit == null:
+			continue
 
-	_end_turn()
+		initiative_entries.append({
+			"unit": unit,
+			"initiative": _calculate_unit_initiative(unit)
+		})
+
+	initiative_entries.sort_custom(_sort_initiative_entries)
+
+	initiative_order.clear()
+	for entry in initiative_entries:
+		initiative_order.append(entry.get("unit", null))
+
+
+func _get_next_initiative_actor() -> PlayerUnit:
+	initiative_cursor += 1
+
+	while initiative_cursor < initiative_order.size():
+		var candidate = initiative_order[initiative_cursor]
+		if candidate and candidate.action_points > 0:
+			return candidate
+		initiative_cursor += 1
+
+	return null
+
+
+func _calculate_unit_initiative(unit: PlayerUnit) -> int:
+	var speed = unit.get_stat("SPD")
+	var role_penalty = -3 if unit.is_goalkeeper() else 0
+	var player_bonus = 2 if unit.is_player_controlled else 0
+	return (speed * 2) + player_bonus + role_penalty + randi_range(0, INITIATIVE_RANDOM_BONUS)
+
+
+func _sort_initiative_entries(a: Dictionary, b: Dictionary) -> bool:
+	var a_initiative = int(a.get("initiative", 0))
+	var b_initiative = int(b.get("initiative", 0))
+
+	if a_initiative == b_initiative:
+		var a_unit = a.get("unit", null)
+		var b_unit = b.get("unit", null)
+		if a_unit == null or b_unit == null:
+			return false
+
+		if a_unit.overall == b_unit.overall:
+			return int(a_unit.get_stat("PAS")) > int(b_unit.get_stat("PAS"))
+		return a_unit.overall > b_unit.overall
+
+	return a_initiative > b_initiative
+
+
+func _is_player_team_unit(unit: PlayerUnit) -> bool:
+	return player_unit != null and unit.is_home_team == player_unit.is_home_team
+
+
+func _update_active_player_selection(unit: PlayerUnit) -> void:
+	if player_unit:
+		player_unit.set_selected(false)
+	
+	if unit == player_unit and unit:
+		player_unit.set_selected(true)
+
+
+func _process_ai_unit_turn(unit: PlayerUnit) -> void:
+	var actions_per_turn = mini(unit.max_action_points, 3)
+	var is_player_team = _is_player_team_unit(unit)
+	var attacking_right = home_attacks_right if unit.is_home_team else not home_attacks_right
+	var tactics = match_data.home_team.tactics if unit.is_home_team else match_data.away_team.tactics
+
+	for _i in range(actions_per_turn):
+		if unit.action_points <= 0:
+			break
+
+		var decision: Dictionary = {}
+		if is_player_team:
+			decision = TeammateAI.take_turn(unit, ball, all_units, match_data, attacking_right)
+		else:
+			decision = OpponentAI.take_turn(unit, ball, all_units, match_data, tactics, attacking_right)
+
+		await _execute_ai_decision(unit, decision)
+
+		# Small delay for visibility
+		await get_tree().create_timer(0.1).timeout
 
 
 func _end_turn() -> void:
@@ -688,46 +793,6 @@ func _reset_positions() -> void:
 
 
 ## AI Processing
-func _process_team_ai() -> void:
-	var team = home_units if player_unit and player_unit.is_home_team else away_units
-	var attacking_right = home_attacks_right if player_unit and player_unit.is_home_team else not home_attacks_right
-
-	for unit in team:
-		if unit == player_unit:
-			continue  # Skip player-controlled unit
-
-		unit.reset_turn()
-
-		# Take up to 3 actions
-		for _i in range(3):
-			if unit.action_points <= 0:
-				break
-
-			var decision = TeammateAI.take_turn(unit, ball, all_units, match_data, attacking_right)
-			await _execute_ai_decision(unit, decision)
-
-			# Small delay for visibility
-			await get_tree().create_timer(0.1).timeout
-
-
-func _process_opponent_ai() -> void:
-	var opponents = away_units if player_unit and player_unit.is_home_team else home_units
-	var attacking_right = not home_attacks_right if player_unit and player_unit.is_home_team else home_attacks_right
-	var tactics = match_data.away_team.tactics if player_unit and player_unit.is_home_team else match_data.home_team.tactics
-
-	for unit in opponents:
-		unit.reset_turn()
-
-		for _i in range(3):
-			if unit.action_points <= 0:
-				break
-
-			var decision = OpponentAI.take_turn(unit, ball, all_units, match_data, tactics, attacking_right)
-			await _execute_ai_decision(unit, decision)
-
-			await get_tree().create_timer(0.1).timeout
-
-
 func _execute_ai_decision(unit: PlayerUnit, decision: Dictionary) -> void:
 	var action = decision.get("action", "none")
 
@@ -901,7 +966,7 @@ func _on_unit_move_completed(unit: PlayerUnit) -> void:
 
 
 func _check_turn_end() -> void:
-	if not player_unit:
+	if not is_player_turn_active or not player_unit:
 		return
 
 	if player_unit.action_points <= 0:

--- a/scripts/match/tactical/match_controller.gd
+++ b/scripts/match/tactical/match_controller.gd
@@ -381,6 +381,7 @@ func _execute_through_ball(target_hex: Vector2i) -> void:
 	var result = ActionResolver.execute_through_ball(player_unit, target_hex, opponents, match_data)
 
 	if result.success:
+		last_passer = player_unit  # Track passer for potential assist
 		ball.start_pass(player_unit, target_hex)
 	else:
 		match result.reason:
@@ -841,6 +842,9 @@ func _on_goal_scored(is_home_goal: bool) -> void:
 		if last_passer and last_passer != scorer and last_passer.is_home_team == scorer.is_home_team:
 			goal_event["assister_id"] = last_passer.unit_id
 			goal_event["assister_name"] = last_passer.unit_name
+			# Record assist in match_data for player career stats and rating
+			if last_passer.is_player_controlled and match_data:
+				match_data.record_event("assist", {"is_player": true})
 
 	# Store goal event for season tracking
 	if is_home_goal:

--- a/scripts/match/tactical/tactical_ui_controller.gd
+++ b/scripts/match/tactical/tactical_ui_controller.gd
@@ -20,6 +20,7 @@ const DribbleMoves = preload("res://scripts/match/tactical/dribble_moves.gd")
 @onready var dribble_btn: Button = get_node("../ActionPanel/VBoxContainer/ButtonGrid/DribbleBtn")
 @onready var tackle_btn: Button = get_node("../ActionPanel/VBoxContainer/ButtonGrid/TackleBtn")
 @onready var end_turn_btn: Button = get_node("../ActionPanel/VBoxContainer/ButtonGrid/EndTurnBtn")
+@onready var substitute_btn: Button = get_node("../ActionPanel/VBoxContainer/ButtonGrid/SubstituteBtn")
 
 @onready var dribble_move_panel: PanelContainer = get_node("../ActionPanel/VBoxContainer/DribbleMovePanel")
 @onready var dribble_move_container: HBoxContainer = get_node("../ActionPanel/VBoxContainer/DribbleMovePanel/VBoxContainer/MoveButtons")
@@ -130,6 +131,7 @@ func _update_button_states() -> void:
 
 	if match_controller.current_phase != MatchController.TurnPhase.PLAYER:
 		_enable_buttons(false)
+		substitute_btn.text = "Substitute"
 		_update_dribble_move_buttons_state()
 		return
 
@@ -153,6 +155,9 @@ func _update_button_states() -> void:
 	tackle_btn.disabled = ap < 1 or not can_tackle
 
 	end_turn_btn.disabled = false
+	substitute_btn.disabled = not match_controller.can_player_substitute()
+	var remaining_subs = match_controller.get_remaining_substitutions()
+	substitute_btn.text = "Substitute (%d)" % remaining_subs
 	_update_dribble_move_buttons_state()
 
 
@@ -177,6 +182,7 @@ func _enable_buttons(enabled: bool) -> void:
 	dribble_btn.disabled = not enabled
 	tackle_btn.disabled = not enabled
 	end_turn_btn.disabled = not enabled
+	substitute_btn.disabled = not enabled
 
 
 func _reset_button_highlights() -> void:
@@ -185,6 +191,7 @@ func _reset_button_highlights() -> void:
 	shoot_btn.modulate = Color.WHITE
 	dribble_btn.modulate = Color.WHITE
 	tackle_btn.modulate = Color.WHITE
+	substitute_btn.modulate = Color.WHITE
 
 
 ## Build dribble move buttons once the player unit is available.
@@ -340,3 +347,10 @@ func _on_end_turn_btn_pressed() -> void:
 	AudioManager.play_ui_click()
 	if match_controller:
 		match_controller.end_player_turn()
+
+
+func _on_substitute_btn_pressed() -> void:
+	AudioManager.play_ui_click()
+	if match_controller and match_controller.can_player_substitute():
+		match_controller.perform_substitution()
+		_update_button_states()

--- a/scripts/season/season_manager.gd
+++ b/scripts/season/season_manager.gd
@@ -439,7 +439,7 @@ func _transition_to_qualifiers() -> void:
 
 	# Check for league champion milestone
 	if current_season.player_won_league():
-		CareerManager._complete_milestone("prefecture_league_champion")
+		CareerManager.award_milestone("prefecture_league_champion", {"source": "season_progress"})
 		print("[SeasonManager] Player won the prefecture league!")
 
 	# Generate qualifier teams (all league teams plus additional)
@@ -468,7 +468,7 @@ func _transition_to_qualifiers() -> void:
 func _handle_qualifier_completion() -> void:
 	if current_season.player_won_qualifiers():
 		print("[SeasonManager] Player won qualifiers, advancing to nationals")
-		CareerManager._complete_milestone("prefecture_qualifier_winner")
+		CareerManager.award_milestone("prefecture_qualifier_winner", {"source": "season_progress"})
 		_transition_to_nationals()
 	else:
 		print("[SeasonManager] Player eliminated from qualifiers")
@@ -487,7 +487,7 @@ func _transition_to_nationals() -> void:
 	print("[SeasonManager] Transitioning to National Championship")
 
 	# Milestone for making it to nationals
-	CareerManager._complete_milestone("national_participant")
+	CareerManager.award_milestone("national_participant", {"source": "season_progress"})
 
 	var player_team = current_season.league.get_player_team()
 	var national_teams = JapaneseSchoolGenerator.generate_national_teams(player_team, 48)
@@ -508,7 +508,7 @@ func _handle_nationals_completion() -> void:
 	if current_season.player_won_nationals():
 		print("[SeasonManager] Player won the National Championship!")
 		# Record milestone
-		CareerManager._complete_milestone("national_champion")
+		CareerManager.award_milestone("national_champion", {"source": "season_progress"})
 	else:
 		print("[SeasonManager] Player eliminated from nationals")
 		player_eliminated.emit("National Championship")
@@ -529,16 +529,16 @@ func _record_nationals_progress_milestones() -> void:
 	match stage:
 		TournamentData.Stage.QUARTER_FINAL:
 			# Lost in quarter finals = made quarter finals
-			CareerManager._complete_milestone("national_quarter_finalist")
+			CareerManager.award_milestone("national_quarter_finalist", {"source": "season_progress"})
 		TournamentData.Stage.SEMI_FINAL:
 			# Lost in semi finals = made quarters and semis
-			CareerManager._complete_milestone("national_quarter_finalist")
-			CareerManager._complete_milestone("national_semi_finalist")
+			CareerManager.award_milestone("national_quarter_finalist", {"source": "season_progress"})
+			CareerManager.award_milestone("national_semi_finalist", {"source": "season_progress"})
 		TournamentData.Stage.FINAL:
 			# Lost in final = made quarters, semis, and final
-			CareerManager._complete_milestone("national_quarter_finalist")
-			CareerManager._complete_milestone("national_semi_finalist")
-			CareerManager._complete_milestone("national_finalist")
+			CareerManager.award_milestone("national_quarter_finalist", {"source": "season_progress"})
+			CareerManager.award_milestone("national_semi_finalist", {"source": "season_progress"})
+			CareerManager.award_milestone("national_finalist", {"source": "season_progress"})
 
 
 func _end_season() -> void:

--- a/scripts/social/social_feed_manager.gd
+++ b/scripts/social/social_feed_manager.gd
@@ -1,0 +1,968 @@
+extends Node
+## SocialFeedManager - Manages the in-game social media feed (FanZone)
+##
+## Owns feed data, subscribes to game event signals, generates NPC posts
+## using persona data, handles player posts/replies, queues NPC auto-replies.
+
+signal post_added(post: Dictionary)
+signal reply_added(parent_post_id: String, reply: Dictionary)
+signal feed_refreshed()
+
+const MAX_FEED_SIZE := 100
+const MAX_REPLIES_PER_POST := 20
+
+# Feed storage - newest first
+var feed: Array[Dictionary] = []
+
+# Post ID counter
+var _next_post_id: int = 1
+
+# NPC auto-reply queue
+var _reply_queue: Array[Dictionary] = []  # [{parent_post_id, npc_id, delay}]
+var _reply_timer: Timer
+
+# Post type constants
+enum PostType {
+	NPC_REACTION,
+	NEWS_ARTICLE,
+	FAN_REACTION,
+	MATCH_SUMMARY,
+	MILESTONE,
+	PLAYER_POST,
+	SEASON_UPDATE,
+	INJURY_REPORT
+}
+
+const POST_TYPE_NAMES := {
+	PostType.NPC_REACTION: "npc_reaction",
+	PostType.NEWS_ARTICLE: "news_article",
+	PostType.FAN_REACTION: "fan_reaction",
+	PostType.MATCH_SUMMARY: "match_summary",
+	PostType.MILESTONE: "milestone",
+	PostType.PLAYER_POST: "player_post",
+	PostType.SEASON_UPDATE: "season_update",
+	PostType.INJURY_REPORT: "injury_report"
+}
+
+# Template pools for NPC text generation by {event}_{personality}
+const NPC_TEMPLATES := {
+	# Match win reactions
+	"match_win_passionate": [
+		"YESSS!! What a match! That's the kind of fire we need!",
+		"We did it!! I'm still buzzing from that game!",
+		"THIS is what soccer is all about! Amazing team effort!"
+	],
+	"match_win_leader": [
+		"Great performance from everyone today. We executed the plan perfectly.",
+		"The team showed real character out there. Proud of every one of you.",
+		"Solid win. But we can't get complacent - next match starts now."
+	],
+	"match_win_calm": [
+		"A well-deserved result. The preparation paid off.",
+		"Good game. We controlled the tempo well today.",
+		"Steady performance. That's how you build consistency."
+	],
+	"match_win_hardworker": [
+		"All that extra training paid off today!",
+		"We earned that win with blood and sweat. Every drill was worth it.",
+		"Hard work gets results. Simple as that."
+	],
+	"match_win_creative": [
+		"Beautiful goals, beautiful passing - that was art on the pitch!",
+		"The pitch was our canvas today and we painted a masterpiece!",
+		"Did you SEE that combination play? Poetry in motion!"
+	],
+	"match_win_aggressive": [
+		"We crushed them! That's how you dominate!",
+		"They couldn't handle us. Total domination!",
+		"That's what happens when you come at us. Get wrecked!"
+	],
+	"match_win_reliable": [
+		"Another solid win for the team. Consistency is key.",
+		"We all did our jobs today. That's how you get results.",
+		"A good team performance. Everyone played their part."
+	],
+	# Match loss reactions
+	"match_loss_passionate": [
+		"I can't believe we lost... We gave everything out there!",
+		"This hurts so much... But we'll come back stronger, I swear it!",
+		"Ugh, what a painful result. We can't let this break us!"
+	],
+	"match_loss_leader": [
+		"Tough loss. We need to regroup and learn from our mistakes.",
+		"We fell short today. I take responsibility. We'll fix this.",
+		"Not our day. But a true team bounces back. We go again."
+	],
+	"match_loss_calm": [
+		"Disappointing result, but there are lessons to take from this.",
+		"We lost control of the match in key moments. We'll analyze and adjust.",
+		"These things happen. What matters is how we respond."
+	],
+	"match_loss_hardworker": [
+		"We didn't work hard enough. Back to the training ground.",
+		"No excuses. We need to train harder and do better.",
+		"Losses like this make you stronger. Time to get to work."
+	],
+	"match_loss_creative": [
+		"Nothing clicked today... the rhythm just wasn't there.",
+		"We couldn't find our flow. Some days the magic doesn't come.",
+		"Frustrating. We had ideas but couldn't execute them."
+	],
+	"match_loss_aggressive": [
+		"This is unacceptable! We need to fight harder!",
+		"I'm furious. We let them walk all over us!",
+		"No way I'm accepting this. Next time we crush them."
+	],
+	"match_loss_reliable": [
+		"A setback, but not the end. We'll come back.",
+		"Tough day. We need to stick to our strengths.",
+		"We weren't ourselves today. Back to basics."
+	],
+	# Match draw reactions
+	"match_draw_passionate": [
+		"So close! A draw feels like a loss when you want it that badly!",
+		"We almost had it! The passion was there, just needed one more goal!"
+	],
+	"match_draw_leader": [
+		"A point gained or two dropped - depends on perspective. We move on.",
+		"We showed resilience to not lose. Now let's work on winning."
+	],
+	"match_draw_calm": [
+		"A fair result given how the match played out.",
+		"Both teams had chances. A draw was reasonable."
+	],
+	"match_draw_hardworker": [
+		"We fought hard but couldn't get the winner. More work needed.",
+		"Close but not enough. We'll get there with more effort."
+	],
+	"match_draw_creative": [
+		"We had some nice moments but couldn't find the finishing touch.",
+		"The ideas were there, execution let us down in the final third."
+	],
+	"match_draw_aggressive": [
+		"A draw?! We should've buried them! So frustrating!",
+		"Not good enough. We had chances to finish it."
+	],
+	"match_draw_reliable": [
+		"A draw isn't ideal but it's a point. We keep building.",
+		"Decent effort from the team. We'll take it and improve."
+	],
+	# Goal reactions
+	"goal_scored_passionate": [
+		"GOOOAAAL!! What a strike! I'm screaming!",
+		"GET IN!! That's what dreams are made of!"
+	],
+	"goal_scored_leader": [
+		"Clinical finish. That's exactly what we needed.",
+		"Great goal. The whole team built up to that moment."
+	],
+	"goal_scored_calm": [
+		"Well taken. Good composure in front of goal.",
+		"Nice goal. Kept it simple and effective."
+	],
+	# Injury reactions
+	"injury_teammate_passionate": [
+		"No!! Please be okay... We're all behind you!",
+		"Get well soon! The team isn't the same without you!"
+	],
+	"injury_teammate_leader": [
+		"Rest up and recover properly. We'll hold the fort.",
+		"Take the time you need. The team will cover for you."
+	],
+	"injury_teammate_calm": [
+		"Wishing a speedy recovery. Focus on rehab.",
+		"Get well soon. Take it one day at a time."
+	],
+	"injury_teammate_hardworker": [
+		"Stay strong! You'll come back even tougher!",
+		"Recovery is just another form of training. You got this!"
+	],
+	"injury_teammate_reliable": [
+		"We'll miss you out there. Get well soon!",
+		"Hope it's nothing serious. Take care of yourself."
+	],
+	# Recovery reactions
+	"recovery_passionate": [
+		"WELCOME BACK!! We missed you so much!",
+		"You're back!! The team is complete again!"
+	],
+	"recovery_leader": [
+		"Good to have you back. Take it easy at first.",
+		"Welcome back. We saved your spot."
+	],
+	"recovery_calm": [
+		"Glad to see you recovered. Welcome back.",
+		"Good to have you back in the squad."
+	],
+	# Milestone reactions
+	"milestone_passionate": [
+		"INCREDIBLE! What an achievement! So proud!",
+		"You absolute legend! This is historic!"
+	],
+	"milestone_leader": [
+		"Well deserved. You've earned this through hard work.",
+		"Congratulations. A milestone like this inspires the whole team."
+	],
+	"milestone_calm": [
+		"Impressive achievement. Congratulations.",
+		"Well earned. Your consistency speaks for itself."
+	],
+	# Player post reactions (for NPC auto-replies)
+	"player_post_passionate": [
+		"Love the energy! That's what I'm talking about!",
+		"YES! This is the spirit we need!",
+		"You always know how to fire up the team!"
+	],
+	"player_post_leader": [
+		"Well said. The team appreciates your words.",
+		"Good point. Let's use that motivation.",
+		"Couldn't agree more."
+	],
+	"player_post_calm": [
+		"Noted. Good thoughts.",
+		"I see your point. Makes sense.",
+		"Fair enough. Interesting perspective."
+	],
+	"player_post_hardworker": [
+		"Actions speak louder but I like the sentiment!",
+		"Let's back that up with results on the pitch!",
+		"Nice post! Now let's go train!"
+	],
+	"player_post_creative": [
+		"Haha, love it! You've got a way with words!",
+		"Poetic! Almost as good as a nutmeg!",
+		"That's the vibe! Keep it coming!"
+	],
+	"player_post_aggressive": [
+		"Let's GO! That's the attitude!",
+		"Now THAT'S what I want to hear!",
+		"Talk is cheap but I like your fire!"
+	],
+	"player_post_reliable": [
+		"Good post! The team vibes are strong.",
+		"Nice one! Always good to hear from you.",
+		"Agreed. We're all in this together."
+	]
+}
+
+# Fan reaction templates
+const FAN_TEMPLATES := {
+	"match_win": [
+		"What a game! These kids are going places!",
+		"Incredible match! So proud of our team!",
+		"That was exciting! Can't wait for the next one!",
+		"Our boys played their hearts out today!"
+	],
+	"match_loss": [
+		"Tough loss but they'll bounce back!",
+		"Keep your heads up, team! We believe in you!",
+		"Not our day, but the effort was there.",
+		"Growing pains. This team has potential."
+	],
+	"match_draw": [
+		"So close! Next time we'll get the win!",
+		"A fair result. The team is improving!",
+		"Good fight from our boys today!"
+	],
+	"milestone": [
+		"History in the making! What a talent!",
+		"Congratulations! The whole school is proud!",
+		"A star is born! Remember this moment!"
+	],
+	"general": [
+		"Go team! We're behind you all the way!",
+		"Can't wait for the next match!",
+		"The future is bright for this squad!"
+	]
+}
+
+# News headline templates
+const NEWS_TEMPLATES := {
+	"match_win": [
+		{"headline": "%s Claims Victory Over %s!", "body": "In a commanding display, %s defeated %s %s in their latest fixture. The team continues to build momentum as the season progresses."},
+		{"headline": "Impressive Win for %s!", "body": "%s put on a strong performance to beat %s %s. The coaching staff will be pleased with the team's execution."}
+	],
+	"match_loss": [
+		{"headline": "%s Fall to %s in Tough Contest", "body": "Despite a spirited effort, %s went down %s to %s. The team will look to bounce back in their next outing."},
+		{"headline": "Setback for %s Against %s", "body": "%s suffered a %s defeat to %s. The coaching staff will be working hard to address the issues before the next match."}
+	],
+	"match_draw": [
+		{"headline": "%s and %s Share the Spoils", "body": "An evenly contested match between %s and %s ended %s. Both teams had chances but neither could find a winner."}
+	],
+	"qualification": [
+		{"headline": "HISTORIC! %s Qualifies for Nationals!", "body": "In an incredible achievement, %s has secured their place in the National Championship. The school is buzzing with excitement as the team prepares for the biggest stage."}
+	],
+	"season_end": [
+		{"headline": "%s Season Comes to an End", "body": "The season has concluded for %s. It's been a journey of growth, challenges, and unforgettable moments. The team will regroup during the off-season."}
+	]
+}
+
+
+func _ready() -> void:
+	print("[SocialFeedManager] Initialized")
+	_setup_reply_timer()
+	_connect_signals()
+
+
+func _setup_reply_timer() -> void:
+	_reply_timer = Timer.new()
+	_reply_timer.one_shot = true
+	_reply_timer.timeout.connect(_process_reply_queue)
+	add_child(_reply_timer)
+
+
+func _connect_signals() -> void:
+	# Season signals
+	if SeasonManager:
+		if SeasonManager.has_signal("phase_changed"):
+			SeasonManager.phase_changed.connect(_on_phase_changed)
+		if SeasonManager.has_signal("league_standings_updated"):
+			SeasonManager.league_standings_updated.connect(_on_standings_updated)
+		if SeasonManager.has_signal("player_qualified_for_nationals"):
+			SeasonManager.player_qualified_for_nationals.connect(_on_qualified_for_nationals)
+		if SeasonManager.has_signal("season_completed"):
+			SeasonManager.season_completed.connect(_on_season_completed)
+
+	# Career signals
+	if CareerManager:
+		if CareerManager.has_signal("milestone_reached"):
+			CareerManager.milestone_reached.connect(_on_milestone_reached)
+
+	# NPC signals
+	if NpcRegistry:
+		if NpcRegistry.has_signal("npc_injured"):
+			NpcRegistry.npc_injured.connect(_on_npc_injured)
+		if NpcRegistry.has_signal("npc_recovered"):
+			NpcRegistry.npc_recovered.connect(_on_npc_recovered)
+
+	# Narrative signals
+	if NarrativeEngine:
+		if NarrativeEngine.has_signal("news_article_generated"):
+			NarrativeEngine.news_article_generated.connect(_on_narrative_news_article)
+
+
+# ─── Post Creation ───────────────────────────────────────────────
+
+func create_post(post_type_name: String, author_id: String, author_name: String,
+		author_role: String, content: String, extra: Dictionary = {}) -> Dictionary:
+	var post = {
+		"post_id": "post_%d" % _next_post_id,
+		"post_type": post_type_name,
+		"author_id": author_id,
+		"author_name": author_name,
+		"author_role": author_role,
+		"author_handle": _generate_handle(author_name),
+		"content": content,
+		"timestamp": Time.get_unix_time_from_system(),
+		"date_string": _get_date_string(),
+		"likes": extra.get("likes", 0),
+		"player_liked": false,
+		"replies": [],
+		"event_type": extra.get("event_type", ""),
+		"mood": extra.get("mood", "neutral")
+	}
+
+	# Merge any extra display data
+	for key in ["score", "headline", "body", "source", "milestone_name"]:
+		if key in extra:
+			post[key] = extra[key]
+
+	_next_post_id += 1
+	_add_to_feed(post)
+	return post
+
+
+func create_npc_post(npc_id: String, content: String, event_type: String = "", mood: String = "neutral") -> Dictionary:
+	var npc_data = _get_npc_display_data(npc_id)
+	return create_post(
+		POST_TYPE_NAMES[PostType.NPC_REACTION],
+		npc_id, npc_data.name, npc_data.role, content,
+		{"event_type": event_type, "mood": mood, "likes": randi_range(5, 50)}
+	)
+
+
+func create_player_post(content: String) -> Dictionary:
+	var player_name = "You"
+	if GameManager.player_data:
+		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
+
+	var post = create_post(
+		POST_TYPE_NAMES[PostType.PLAYER_POST],
+		"player", player_name, "player", content,
+		{"likes": randi_range(10, 80)}
+	)
+
+	# Queue NPC auto-replies
+	_queue_npc_replies(post.post_id, "player_post")
+	return post
+
+
+func add_reply(parent_post_id: String, author_id: String, author_name: String,
+		author_role: String, content: String) -> Dictionary:
+	var reply = {
+		"post_id": "reply_%d" % _next_post_id,
+		"post_type": "reply",
+		"author_id": author_id,
+		"author_name": author_name,
+		"author_role": author_role,
+		"author_handle": _generate_handle(author_name),
+		"content": content,
+		"timestamp": Time.get_unix_time_from_system(),
+		"date_string": _get_date_string(),
+		"likes": 0,
+		"player_liked": false
+	}
+	_next_post_id += 1
+
+	# Find parent post and add reply
+	for post in feed:
+		if post.post_id == parent_post_id:
+			if post.replies.size() < MAX_REPLIES_PER_POST:
+				post.replies.append(reply)
+			reply_added.emit(parent_post_id, reply)
+			return reply
+
+	return reply
+
+
+func add_player_reply(parent_post_id: String, content: String) -> Dictionary:
+	var player_name = "You"
+	if GameManager.player_data:
+		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
+
+	var reply = add_reply(parent_post_id, "player", player_name, "player", content)
+
+	# Queue NPC auto-replies to the thread
+	_queue_npc_replies(parent_post_id, "player_post")
+	return reply
+
+
+# ─── Like System ─────────────────────────────────────────────────
+
+func toggle_like(post_id: String) -> void:
+	var post = get_post_by_id(post_id)
+	if post.is_empty():
+		# Check replies
+		for p in feed:
+			for r in p.replies:
+				if r.post_id == post_id:
+					r.player_liked = !r.player_liked
+					r.likes += 1 if r.player_liked else -1
+					return
+		return
+
+	post.player_liked = !post.player_liked
+	post.likes += 1 if post.player_liked else -1
+
+
+# ─── Feed Access ─────────────────────────────────────────────────
+
+func get_feed(filter: String = "all") -> Array[Dictionary]:
+	if filter == "all":
+		return feed
+
+	var filtered: Array[Dictionary] = []
+	for post in feed:
+		match filter:
+			"npc":
+				if post.post_type == "npc_reaction":
+					filtered.append(post)
+			"news":
+				if post.post_type in ["news_article", "match_summary", "season_update", "injury_report"]:
+					filtered.append(post)
+			"my_posts":
+				if post.author_id == "player":
+					filtered.append(post)
+			"milestones":
+				if post.post_type == "milestone":
+					filtered.append(post)
+	return filtered
+
+
+func get_post_by_id(post_id: String) -> Dictionary:
+	for post in feed:
+		if post.post_id == post_id:
+			return post
+	return {}
+
+
+# ─── NPC Text Generation ────────────────────────────────────────
+
+func _generate_npc_text(npc_id: String, event_key: String) -> String:
+	var persona = PersonaManager.get_persona(npc_id) if PersonaManager else null
+	var personality = "reliable"  # fallback
+
+	if persona and not persona.personality_traits.is_empty():
+		# Map persona traits to our template personality categories
+		personality = _map_traits_to_personality(persona.personality_traits)
+
+	# Try specific template
+	var template_key = "%s_%s" % [event_key, personality]
+	if template_key in NPC_TEMPLATES:
+		var templates = NPC_TEMPLATES[template_key]
+		return templates[randi() % templates.size()]
+
+	# Fallback: try event with "reliable" personality
+	var fallback_key = "%s_reliable" % event_key
+	if fallback_key in NPC_TEMPLATES:
+		var templates = NPC_TEMPLATES[fallback_key]
+		return templates[randi() % templates.size()]
+
+	# Final fallback - use catchphrase if available
+	if persona and not persona.catchphrases.is_empty():
+		return persona.catchphrases[randi() % persona.catchphrases.size()]
+
+	return "Great effort from the team today!"
+
+
+func _map_traits_to_personality(traits: Array[String]) -> String:
+	# Map persona traits to template personality categories
+	var trait_map = {
+		"commanding": "leader", "protective": "leader", "responsible": "leader",
+		"diligent": "hardworker", "humble": "hardworker", "persistent": "hardworker", "disciplined": "hardworker",
+		"imaginative": "creative", "unpredictable": "creative", "expressive": "creative", "intuitive": "creative",
+		"intense": "aggressive", "competitive": "aggressive", "fearless": "aggressive",
+		"composed": "calm", "analytical": "calm", "patient": "calm", "steady": "calm",
+		"emotional": "passionate", "inspiring": "passionate", "dramatic": "passionate", "wholehearted": "passionate",
+		"consistent": "reliable", "trustworthy": "reliable", "supportive": "reliable", "dependable": "reliable"
+	}
+
+	for trait in traits:
+		var lower_trait = trait.to_lower()
+		if lower_trait in trait_map:
+			return trait_map[lower_trait]
+
+	return "reliable"
+
+
+func _get_npc_display_data(npc_id: String) -> Dictionary:
+	var data = {"name": "Unknown", "role": "teammate", "position": ""}
+
+	# Try NPC registry first
+	if NpcRegistry and NpcRegistry.has_npc(npc_id):
+		var npc = NpcRegistry.get_npc(npc_id)
+		data.name = npc.get("name", "Unknown")
+		data.position = npc.get("position", "")
+
+	# Try persona for role
+	if PersonaManager and PersonaManager.has_persona(npc_id):
+		var persona = PersonaManager.get_persona(npc_id)
+		if persona:
+			data.role = persona.role
+			if data.name == "Unknown":
+				data.name = persona.name
+
+	# Determine if teammate or rival
+	if GameManager.current_team:
+		var player = GameManager.current_team.get_player_by_id(npc_id)
+		if not player.is_empty():
+			data.role = "teammate"
+			data.name = player.get("name", data.name)
+			data.position = player.get("position", data.position)
+		else:
+			if data.role == "teammate":
+				data.role = "rival"  # Not on our team
+
+	return data
+
+
+# ─── NPC Auto-Reply Queue ───────────────────────────────────────
+
+func _queue_npc_replies(parent_post_id: String, event_key: String) -> void:
+	var npcs = _select_replying_npcs()
+
+	for i in range(npcs.size()):
+		_reply_queue.append({
+			"parent_post_id": parent_post_id,
+			"npc_id": npcs[i],
+			"event_key": event_key,
+			"delay": 2.0 if i == 0 else randf_range(1.5, 3.0)
+		})
+
+	if not _reply_queue.is_empty() and _reply_timer.is_stopped():
+		_reply_timer.start(_reply_queue[0].delay)
+
+
+func _select_replying_npcs() -> Array[String]:
+	var candidates: Array[String] = []
+
+	# Get teammates from current team
+	if GameManager.current_team:
+		for player in GameManager.current_team.players:
+			var pid = player.get("id", "")
+			if pid != "" and pid != "player":
+				candidates.append(pid)
+
+	if candidates.is_empty():
+		return []
+
+	# Shuffle and select 1-3 NPCs, preferring passionate/leader types
+	candidates.shuffle()
+	var count = mini(randi_range(1, 3), candidates.size())
+	var selected: Array[String] = []
+
+	# Priority pass: pick passionate/leader personalities first
+	for npc_id in candidates:
+		if selected.size() >= count:
+			break
+		var persona = PersonaManager.get_persona(npc_id) if PersonaManager else null
+		if persona:
+			var personality = _map_traits_to_personality(persona.personality_traits)
+			if personality in ["passionate", "leader", "aggressive"]:
+				selected.append(npc_id)
+
+	# Fill remaining slots randomly
+	for npc_id in candidates:
+		if selected.size() >= count:
+			break
+		if npc_id not in selected:
+			selected.append(npc_id)
+
+	return selected
+
+
+func _process_reply_queue() -> void:
+	if _reply_queue.is_empty():
+		return
+
+	var item = _reply_queue.pop_front()
+	var npc_data = _get_npc_display_data(item.npc_id)
+	var text = _generate_npc_text(item.npc_id, item.event_key)
+
+	add_reply(item.parent_post_id, item.npc_id, npc_data.name, npc_data.role, text)
+
+	# Schedule next reply if queue has more
+	if not _reply_queue.is_empty():
+		_reply_timer.start(_reply_queue[0].delay)
+
+
+# ─── Event Handlers ──────────────────────────────────────────────
+
+func on_match_ended(result: Dictionary) -> void:
+	var player_team_name = result.get("player_team", "Our Team")
+	var opponent_name = result.get("opponent", "Opponent")
+	var home_score = result.get("home_score", 0)
+	var away_score = result.get("away_score", 0)
+	var is_home = result.get("is_home", true)
+
+	var player_score = home_score if is_home else away_score
+	var opponent_score = away_score if is_home else home_score
+	var score_str = "%d-%d" % [player_score, opponent_score]
+
+	# Determine result type
+	var result_type = "draw"
+	var mood = "neutral"
+	if player_score > opponent_score:
+		result_type = "win"
+		mood = "happy"
+	elif player_score < opponent_score:
+		result_type = "loss"
+		mood = "sad"
+
+	# Match summary post
+	var summary_content = "%s %s %s" % [player_team_name, score_str, opponent_name]
+	if result_type == "win":
+		summary_content += " - Victory!"
+	elif result_type == "loss":
+		summary_content += " - Defeat"
+	else:
+		summary_content += " - Draw"
+
+	create_post(
+		POST_TYPE_NAMES[PostType.MATCH_SUMMARY],
+		"system", "Match Report", "system", summary_content,
+		{"event_type": "match_" + result_type, "mood": mood,
+		 "score": score_str, "likes": randi_range(30, 150)}
+	)
+
+	# NPC reactions (2-4 from teammates)
+	var event_key = "match_" + result_type
+	_generate_npc_event_posts(event_key, mood, randi_range(2, 4))
+
+	# Fan reactions (0-2)
+	var fan_count = randi_range(0, 2)
+	for i in range(fan_count):
+		var fan_templates = FAN_TEMPLATES.get("match_" + result_type, FAN_TEMPLATES["general"])
+		var fan_text = fan_templates[randi() % fan_templates.size()]
+		create_post(
+			POST_TYPE_NAMES[PostType.FAN_REACTION],
+			"fan_%d" % randi(), "Soccer Fan", "fan", fan_text,
+			{"event_type": event_key, "mood": mood, "likes": randi_range(2, 20)}
+		)
+
+	# News article
+	var news_list = NEWS_TEMPLATES.get("match_" + result_type, [])
+	if not news_list.is_empty():
+		var template = news_list[randi() % news_list.size()]
+		var headline = ""
+		var body = ""
+		match result_type:
+			"win":
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, opponent_name, score_str]
+			"loss":
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, score_str, opponent_name]
+			"draw":
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, opponent_name, score_str]
+
+		create_post(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone News", "news", headline,
+			{"headline": headline, "body": body, "source": "FanZone Sports Desk",
+			 "event_type": event_key, "likes": randi_range(20, 100)}
+		)
+
+
+func _on_phase_changed(new_phase: int) -> void:
+	var phase_names = {
+		0: "Pre-Season",
+		1: "League Stage",
+		2: "Qualifiers",
+		3: "Nationals",
+		4: "Post-Season"
+	}
+	var phase_name = phase_names.get(new_phase, "New Phase")
+
+	create_post(
+		POST_TYPE_NAMES[PostType.SEASON_UPDATE],
+		"system", "Season Update", "system",
+		"The %s has begun! A new chapter of our journey starts now." % phase_name,
+		{"event_type": "phase_changed", "mood": "excited", "likes": randi_range(15, 60)}
+	)
+
+
+func _on_standings_updated(_standings: Array[Dictionary]) -> void:
+	pass  # Could add periodic standings update posts
+
+
+func _on_qualified_for_nationals() -> void:
+	var team_name = "Our Team"
+	if GameManager.current_team:
+		team_name = GameManager.current_team.name
+
+	# Milestone post
+	create_post(
+		POST_TYPE_NAMES[PostType.MILESTONE],
+		"system", "Achievement", "system",
+		"QUALIFIED FOR NATIONALS! %s is heading to the National Championship!" % team_name,
+		{"event_type": "qualification", "mood": "ecstatic",
+		 "milestone_name": "National Qualification", "likes": randi_range(100, 300)}
+	)
+
+	# NPC celebrations (3-5)
+	_generate_npc_event_posts("milestone", "ecstatic", randi_range(3, 5))
+
+	# Fan reactions (2-3)
+	var fan_templates = FAN_TEMPLATES["milestone"]
+	for i in range(randi_range(2, 3)):
+		create_post(
+			POST_TYPE_NAMES[PostType.FAN_REACTION],
+			"fan_%d" % randi(), "Excited Fan", "fan",
+			fan_templates[randi() % fan_templates.size()],
+			{"event_type": "qualification", "mood": "ecstatic", "likes": randi_range(10, 50)}
+		)
+
+	# News article
+	var news_list = NEWS_TEMPLATES["qualification"]
+	if not news_list.is_empty():
+		var template = news_list[randi() % news_list.size()]
+		create_post(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone News", "news",
+			template.headline % team_name,
+			{"headline": template.headline % team_name, "body": template.body % team_name,
+			 "source": "FanZone Sports Desk", "event_type": "qualification",
+			 "likes": randi_range(50, 200)}
+		)
+
+
+func _on_season_completed(summary: Dictionary) -> void:
+	var team_name = "Our Team"
+	if GameManager.current_team:
+		team_name = GameManager.current_team.name
+
+	create_post(
+		POST_TYPE_NAMES[PostType.SEASON_UPDATE],
+		"system", "Season Update", "system",
+		"The season has come to an end for %s. What a journey it's been!" % team_name,
+		{"event_type": "season_end", "mood": "reflective", "likes": randi_range(30, 100)}
+	)
+
+	# News article
+	var news_list = NEWS_TEMPLATES["season_end"]
+	if not news_list.is_empty():
+		var template = news_list[randi() % news_list.size()]
+		create_post(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone News", "news",
+			template.headline % team_name,
+			{"headline": template.headline % team_name, "body": template.body % team_name,
+			 "source": "FanZone Sports Desk", "event_type": "season_end",
+			 "likes": randi_range(30, 120)}
+		)
+
+
+func _on_milestone_reached(milestone: String) -> void:
+	var player_name = "Our Star"
+	if GameManager.player_data:
+		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "Our Star"
+
+	create_post(
+		POST_TYPE_NAMES[PostType.MILESTONE],
+		"system", "Achievement", "system",
+		"%s reached a new milestone: %s!" % [player_name, milestone.replace("_", " ").capitalize()],
+		{"event_type": "milestone", "mood": "proud",
+		 "milestone_name": milestone, "likes": randi_range(40, 150)}
+	)
+
+	# NPC congratulations (1-2)
+	_generate_npc_event_posts("milestone", "proud", randi_range(1, 2))
+
+
+func _on_npc_injured(npc_id: String, injury: Dictionary) -> void:
+	var npc_data = _get_npc_display_data(npc_id)
+	var matches_out = injury.get("matches_remaining", 0)
+	var description = injury.get("description", "injury")
+
+	create_post(
+		POST_TYPE_NAMES[PostType.INJURY_REPORT],
+		"system", "Medical Update", "system",
+		"%s has suffered a %s and will miss %d match%s." % [
+			npc_data.name, description, matches_out,
+			"es" if matches_out != 1 else ""
+		],
+		{"event_type": "injury", "mood": "concerned", "likes": randi_range(10, 40)}
+	)
+
+	# Get-well NPC posts (1-2)
+	_generate_npc_injury_posts(npc_id, randi_range(1, 2))
+
+
+func _on_npc_recovered(npc_id: String) -> void:
+	var npc_data = _get_npc_display_data(npc_id)
+
+	create_post(
+		POST_TYPE_NAMES[PostType.NPC_REACTION],
+		npc_id, npc_data.name, npc_data.role,
+		"I'm back! Feeling good and ready to play again!",
+		{"event_type": "recovery", "mood": "happy", "likes": randi_range(15, 60)}
+	)
+
+	# Welcome-back posts (1-2)
+	_generate_npc_recovery_posts(npc_id, randi_range(1, 2))
+
+
+func _on_narrative_news_article(article: Dictionary) -> void:
+	create_post(
+		POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+		"news", article.get("author", "FanZone"), "news",
+		article.get("headline", "News Update"),
+		{"headline": article.get("headline", "News Update"),
+		 "body": article.get("body", ""),
+		 "source": article.get("author", "FanZone"),
+		 "likes": randi_range(20, 100)}
+	)
+
+
+# ─── NPC Post Generation Helpers ────────────────────────────────
+
+func _generate_npc_event_posts(event_key: String, mood: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var npc_id = npcs[i]
+		var text = _generate_npc_text(npc_id, event_key)
+		create_npc_post(npc_id, text, event_key, mood)
+
+
+func _generate_npc_injury_posts(injured_npc_id: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.erase(injured_npc_id)
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var text = _generate_npc_text(npcs[i], "injury_teammate")
+		create_npc_post(npcs[i], text, "injury", "concerned")
+
+
+func _generate_npc_recovery_posts(recovered_npc_id: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.erase(recovered_npc_id)
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var text = _generate_npc_text(npcs[i], "recovery")
+		create_npc_post(npcs[i], text, "recovery", "happy")
+
+
+func _get_available_teammate_npcs() -> Array[String]:
+	var npcs: Array[String] = []
+	if GameManager.current_team:
+		for player in GameManager.current_team.players:
+			var pid = player.get("id", "")
+			if pid != "" and pid != "player":
+				npcs.append(pid)
+	return npcs
+
+
+# ─── Internal Helpers ────────────────────────────────────────────
+
+func _add_to_feed(post: Dictionary) -> void:
+	feed.insert(0, post)
+	if feed.size() > MAX_FEED_SIZE:
+		feed.resize(MAX_FEED_SIZE)
+	post_added.emit(post)
+
+
+func _generate_handle(author_name: String) -> String:
+	if author_name == "You" or author_name == "player":
+		return "@you"
+	if author_name in ["FanZone News", "Match Report", "Medical Update", "Season Update", "Achievement"]:
+		return "@fanzone"
+	# Generate handle from name: "Takumi Yamada" -> "@t_yamada"
+	var parts = author_name.split(" ")
+	if parts.size() >= 2:
+		return "@%s_%s" % [parts[0][0].to_lower(), parts[-1].to_lower()]
+	return "@%s" % author_name.to_lower().replace(" ", "_")
+
+
+func _get_date_string() -> String:
+	if DesktopManager:
+		return DesktopManager.get_date_string()
+	return Time.get_date_string_from_system()
+
+
+# ─── Welcome Post ────────────────────────────────────────────────
+
+func ensure_welcome_post() -> void:
+	if feed.is_empty():
+		create_post(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone Staff", "news",
+			"A New Star Joins the Ranks!",
+			{"headline": "A New Star Joins the Ranks!",
+			 "body": "The local football community is buzzing with excitement as a promising young talent begins their career journey. We'll be following their progress closely!",
+			 "source": "FanZone Staff", "likes": randi_range(50, 200)}
+		)
+
+
+# ─── Serialization ───────────────────────────────────────────────
+
+func to_dict() -> Dictionary:
+	return {
+		"feed": feed,
+		"next_post_id": _next_post_id
+	}
+
+
+func from_dict(data: Dictionary) -> void:
+	feed.assign(data.get("feed", []))
+	_next_post_id = data.get("next_post_id", feed.size() + 1)
+	feed_refreshed.emit()
+	print("[SocialFeedManager] Loaded %d posts from save" % feed.size())

--- a/scripts/social/social_feed_manager.gd
+++ b/scripts/social/social_feed_manager.gd
@@ -18,7 +18,7 @@ const V2_SORT_TOP := "top"
 const V2_SORT_LATEST := "latest"
 const V2_RECENCY_HALFLIFE_HOURS := 72.0
 const V2_REPLY_DEDUPE_WINDOW_SECONDS := 180.0
-const V2_MAX_SOCIAL_REP_PER_DAY := 2
+const V2_MAX_SOCIAL_REP_PER_DAY := 4
 const V2_THREAD_MIN_LIKES := 2
 const V2_THREAD_MIN_NPC_REPLIES := 2
 
@@ -424,6 +424,8 @@ func create_player_post(content: String) -> Dictionary:
 		{"likes": randi_range(10, 80)}
 	)
 
+	_apply_social_reputation_event("player_post", {"post_id": post.get("post_id", "")})
+
 	# Queue NPC auto-replies
 	_queue_npc_replies(post.post_id, "player_post")
 	return post
@@ -463,6 +465,7 @@ func add_player_reply(parent_post_id: String, content: String) -> Dictionary:
 		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
 
 	var reply = add_reply(parent_post_id, "player", player_name, "player", content)
+	_apply_social_reputation_event("player_reply", {"parent_post_id": parent_post_id})
 
 	# Queue NPC auto-replies to the thread
 	_queue_npc_replies(parent_post_id, "player_post")
@@ -485,6 +488,8 @@ func toggle_like(post_id: String) -> void:
 
 	post.player_liked = !post.player_liked
 	post.likes += 1 if post.player_liked else -1
+	if post.player_liked:
+		_apply_social_reputation_event("like", {"post_type": str(post.get("post_type", "")), "liked": true})
 
 
 # ─── Feed Access ─────────────────────────────────────────────────
@@ -601,6 +606,7 @@ func create_player_post_v2(content: String) -> Dictionary:
 		"player", player_name, "player", content,
 		{"likes": randi_range(10, 80), "priority": 58, "tags": ["player", "thread"]}
 	)
+	_apply_social_reputation_event("player_post", {"post_id": post.get("post_id", "")})
 
 	_queue_npc_replies_v2(post.post_id, "player_post")
 	return post
@@ -644,6 +650,7 @@ func add_player_reply_v2(parent_post_id: String, content: String) -> Dictionary:
 		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
 
 	var reply = add_reply_v2(parent_post_id, "player", player_name, "player", content)
+	_apply_social_reputation_event("player_reply", {"parent_post_id": parent_post_id})
 	var post = get_post_by_id_v2(parent_post_id)
 	if not post.is_empty():
 		post.player_replied_in_thread = true
@@ -665,6 +672,8 @@ func toggle_like_v2(post_id: String) -> void:
 
 	post.player_liked = !post.player_liked
 	post.likes += 1 if post.player_liked else -1
+	if post.player_liked:
+		_apply_social_reputation_event("like", {"post_type": str(post.get("post_type", "")), "liked": true})
 	_evaluate_v2_thread_engagement(post)
 
 
@@ -713,6 +722,7 @@ func on_match_ended_v2(result: Dictionary) -> void:
 	var result_type = normalized.result_type
 	var mood = normalized.mood
 	var event_key = "match_" + result_type
+	var presence_bonus = _get_reputation_presence_bonus()
 
 	var summary_content = "%s %s %s" % [player_team_name, score_str, opponent_name]
 	if result_type == "win":
@@ -729,16 +739,19 @@ func on_match_ended_v2(result: Dictionary) -> void:
 			"event_type": event_key,
 			"mood": mood,
 			"score": score_str,
-			"likes": randi_range(30, 150),
+			"likes": randi_range(30 + (presence_bonus * 8), 150 + (presence_bonus * 15)),
 			"priority": 84,
 			"tags": ["match", result_type, "summary"],
 			"social_rep_eligible": false
 		}
 	)
 
-	_generate_npc_event_posts_v2(event_key, mood, randi_range(2, 4))
+	var npc_min = 2 + (1 if presence_bonus > 0 else 0)
+	var npc_max = 4 + presence_bonus
+	_generate_npc_event_posts_v2(event_key, mood, randi_range(npc_min, npc_max))
 
-	var fan_count = randi_range(0, 2)
+	var fan_count = randi_range(0, 2 + presence_bonus)
+	var fan_like_range = _scaled_like_range(2, 20)
 	for i in range(fan_count):
 		var fan_templates = FAN_TEMPLATES.get(event_key, FAN_TEMPLATES["general"])
 		var fan_text = fan_templates[randi() % fan_templates.size()]
@@ -748,12 +761,13 @@ func on_match_ended_v2(result: Dictionary) -> void:
 			{
 				"event_type": event_key,
 				"mood": mood,
-				"likes": randi_range(2, 20),
+				"likes": randi_range(fan_like_range.x, fan_like_range.y),
 				"priority": 48,
 				"tags": ["fan", result_type]
 			}
 		)
 
+	var news_like_range = _scaled_like_range(20, 100)
 	var news_list = NEWS_TEMPLATES.get(event_key, [])
 	if not news_list.is_empty():
 		var template = news_list[randi() % news_list.size()]
@@ -778,7 +792,7 @@ func on_match_ended_v2(result: Dictionary) -> void:
 				"body": body,
 				"source": "FanZone Sports Desk",
 				"event_type": event_key,
-				"likes": randi_range(20, 100),
+				"likes": randi_range(news_like_range.x, news_like_range.y),
 				"priority": 78,
 				"tags": ["news", "match", result_type],
 				"social_rep_eligible": false
@@ -1050,15 +1064,24 @@ func _grant_v2_social_reputation(delta: int, reason: String) -> bool:
 		return false
 	_sync_v2_social_rep_day()
 	var remaining = maxi(V2_MAX_SOCIAL_REP_PER_DAY - _v2_social_rep_awarded_today, 0)
-	var applied = mini(delta, remaining)
-	if applied <= 0:
+	if remaining <= 0:
 		return false
 
-	if CareerManager and CareerManager.has_method("apply_social_reputation_delta"):
-		CareerManager.apply_social_reputation_delta(applied, reason)
-		_v2_social_rep_awarded_today += applied
-		return true
-	return false
+	var requested = mini(delta, remaining)
+	var result := {}
+	if CareerManager and CareerManager.has_method("apply_social_reputation"):
+		result = CareerManager.apply_social_reputation("legacy_bonus", {"base_delta": requested, "reason": reason})
+	elif CareerManager and CareerManager.has_method("apply_social_reputation_delta"):
+		CareerManager.apply_social_reputation_delta(requested, reason)
+		result = {"applied_delta": requested}
+	else:
+		return false
+
+	var applied = int(result.get("applied_delta", 0))
+	if applied <= 0:
+		return false
+	_v2_social_rep_awarded_today += applied
+	return true
 
 
 func _sync_v2_social_rep_day() -> void:
@@ -1245,28 +1268,51 @@ func _to_string_array(value: Variant) -> Array[String]:
 	return output
 
 
+func _apply_social_reputation_event(action_type: String, payload: Dictionary = {}) -> Dictionary:
+	if not CareerManager:
+		return {}
+	if CareerManager.has_method("apply_social_reputation"):
+		return CareerManager.apply_social_reputation(action_type, payload)
+	if CareerManager.has_method("apply_social_reputation_delta"):
+		var legacy_delta = int(payload.get("base_delta", 0))
+		if legacy_delta > 0:
+			CareerManager.apply_social_reputation_delta(legacy_delta, action_type)
+		return {"applied_delta": legacy_delta}
+	return {}
+
+
+func _get_reputation_score() -> int:
+	if CareerManager:
+		return int(CareerManager.reputation)
+	return 10
+
+
+func _get_reputation_presence_bonus() -> int:
+	var score = _get_reputation_score()
+	if score >= 85:
+		return 2
+	if score >= 50:
+		return 1
+	return 0
+
+
+func _scaled_like_range(min_likes: int, max_likes: int) -> Vector2i:
+	var bonus = _get_reputation_presence_bonus()
+	return Vector2i(min_likes + (bonus * 4), max_likes + (bonus * 12))
+
+
 # ─── Event Handlers ──────────────────────────────────────────────
 
 func on_match_ended(result: Dictionary) -> void:
-	var player_team_name = result.get("player_team", "Our Team")
-	var opponent_name = result.get("opponent", "Opponent")
-	var home_score = result.get("home_score", 0)
-	var away_score = result.get("away_score", 0)
-	var is_home = result.get("is_home", true)
-
-	var player_score = home_score if is_home else away_score
-	var opponent_score = away_score if is_home else home_score
+	var normalized = _normalize_match_result_for_feed(result)
+	var player_team_name = normalized.player_team_name
+	var opponent_name = normalized.opponent_name
+	var player_score = normalized.player_score
+	var opponent_score = normalized.opponent_score
+	var result_type = normalized.result_type
+	var mood = normalized.mood
 	var score_str = "%d-%d" % [player_score, opponent_score]
-
-	# Determine result type
-	var result_type = "draw"
-	var mood = "neutral"
-	if player_score > opponent_score:
-		result_type = "win"
-		mood = "happy"
-	elif player_score < opponent_score:
-		result_type = "loss"
-		mood = "sad"
+	var presence_bonus = _get_reputation_presence_bonus()
 
 	# Match summary post
 	var summary_content = "%s %s %s" % [player_team_name, score_str, opponent_name]
@@ -1281,25 +1327,29 @@ func on_match_ended(result: Dictionary) -> void:
 		POST_TYPE_NAMES[PostType.MATCH_SUMMARY],
 		"system", "Match Report", "system", summary_content,
 		{"event_type": "match_" + result_type, "mood": mood,
-		 "score": score_str, "likes": randi_range(30, 150)}
+		 "score": score_str, "likes": randi_range(30 + (presence_bonus * 8), 150 + (presence_bonus * 15))}
 	)
 
 	# NPC reactions (2-4 from teammates)
 	var event_key = "match_" + result_type
-	_generate_npc_event_posts(event_key, mood, randi_range(2, 4))
+	var npc_min = 2 + (1 if presence_bonus > 0 else 0)
+	var npc_max = 4 + presence_bonus
+	_generate_npc_event_posts(event_key, mood, randi_range(npc_min, npc_max))
 
 	# Fan reactions (0-2)
-	var fan_count = randi_range(0, 2)
+	var fan_count = randi_range(0, 2 + presence_bonus)
+	var fan_like_range = _scaled_like_range(2, 20)
 	for i in range(fan_count):
 		var fan_templates = FAN_TEMPLATES.get("match_" + result_type, FAN_TEMPLATES["general"])
 		var fan_text = fan_templates[randi() % fan_templates.size()]
 		create_post(
 			POST_TYPE_NAMES[PostType.FAN_REACTION],
 			"fan_%d" % randi(), "Soccer Fan", "fan", fan_text,
-			{"event_type": event_key, "mood": mood, "likes": randi_range(2, 20)}
+			{"event_type": event_key, "mood": mood, "likes": randi_range(fan_like_range.x, fan_like_range.y)}
 		)
 
 	# News article
+	var news_like_range = _scaled_like_range(20, 100)
 	var news_list = NEWS_TEMPLATES.get("match_" + result_type, [])
 	if not news_list.is_empty():
 		var template = news_list[randi() % news_list.size()]
@@ -1320,7 +1370,7 @@ func on_match_ended(result: Dictionary) -> void:
 			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
 			"news", "FanZone News", "news", headline,
 			{"headline": headline, "body": body, "source": "FanZone Sports Desk",
-			 "event_type": event_key, "likes": randi_range(20, 100)}
+			 "event_type": event_key, "likes": randi_range(news_like_range.x, news_like_range.y)}
 		)
 
 

--- a/scripts/social/social_feed_manager.gd
+++ b/scripts/social/social_feed_manager.gd
@@ -7,19 +7,41 @@ extends Node
 signal post_added(post: Dictionary)
 signal reply_added(parent_post_id: String, reply: Dictionary)
 signal feed_refreshed()
+signal post_added_v2(post: Dictionary)
+signal reply_added_v2(parent_post_id: String, reply: Dictionary)
+signal feed_refreshed_v2()
 
 const MAX_FEED_SIZE := 100
 const MAX_REPLIES_PER_POST := 20
+const V2_SCHEMA_VERSION := 2
+const V2_SORT_TOP := "top"
+const V2_SORT_LATEST := "latest"
+const V2_RECENCY_HALFLIFE_HOURS := 72.0
+const V2_REPLY_DEDUPE_WINDOW_SECONDS := 180.0
+const V2_MAX_SOCIAL_REP_PER_DAY := 2
+const V2_THREAD_MIN_LIKES := 2
+const V2_THREAD_MIN_NPC_REPLIES := 2
 
 # Feed storage - newest first
 var feed: Array[Dictionary] = []
+var feed_v2: Array[Dictionary] = []
 
 # Post ID counter
 var _next_post_id: int = 1
+var _next_post_id_v2: int = 1
 
 # NPC auto-reply queue
 var _reply_queue: Array[Dictionary] = []  # [{parent_post_id, npc_id, delay}]
 var _reply_timer: Timer
+var _reply_queue_v2: Array[Dictionary] = []  # [{parent_post_id, npc_id, event_key, delay}]
+var _reply_timer_v2: Timer
+var _v2_recent_reply_keys: Dictionary = {}  # "{post}:{npc}" -> timestamp
+var _v2_last_reply_npc_by_thread: Dictionary = {}  # post_id -> npc_id
+var _v2_social_rep_day_key: String = ""
+var _v2_social_rep_awarded_today: int = 0
+var _v2_first_npc_reply_awarded: Dictionary = {}  # post_id -> bool
+var _v2_thread_engagement_awarded: Dictionary = {}  # post_id -> bool
+var _v2_notification_day_by_post: Dictionary = {}  # post_id -> day_key
 
 # Post type constants
 enum PostType {
@@ -310,6 +332,11 @@ func _setup_reply_timer() -> void:
 	_reply_timer.timeout.connect(_process_reply_queue)
 	add_child(_reply_timer)
 
+	_reply_timer_v2 = Timer.new()
+	_reply_timer_v2.one_shot = true
+	_reply_timer_v2.timeout.connect(_process_reply_queue_v2)
+	add_child(_reply_timer_v2)
+
 
 func _connect_signals() -> void:
 	# Season signals
@@ -339,6 +366,11 @@ func _connect_signals() -> void:
 	if NarrativeEngine:
 		if NarrativeEngine.has_signal("news_article_generated"):
 			NarrativeEngine.news_article_generated.connect(_on_narrative_news_article)
+
+	# Match lifecycle signal
+	if GameManager and GameManager.has_signal("match_ended"):
+		if not GameManager.match_ended.is_connected(on_match_ended_v2):
+			GameManager.match_ended.connect(on_match_ended_v2)
 
 
 # ─── Post Creation ───────────────────────────────────────────────
@@ -484,6 +516,274 @@ func get_post_by_id(post_id: String) -> Dictionary:
 		if post.post_id == post_id:
 			return post
 	return {}
+
+
+func is_v2_enabled() -> bool:
+	return bool(ProjectSettings.get_setting("debug/fanzone_v2_enabled", false))
+
+
+func ensure_welcome_post_v2() -> void:
+	if feed_v2.is_empty():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone Staff", "news",
+			"A New Star Joins the Ranks!",
+			{
+				"headline": "A New Star Joins the Ranks!",
+				"body": "The local football community is buzzing with excitement as a promising young talent begins their career journey. We'll be following their progress closely!",
+				"source": "FanZone Staff",
+				"likes": randi_range(50, 200),
+				"event_type": "welcome",
+				"priority": 70,
+				"tags": ["welcome", "news"]
+			}
+		)
+
+
+func create_post_v2(post_type_name: String, author_id: String, author_name: String,
+		author_role: String, content: String, extra: Dictionary = {}) -> Dictionary:
+	var timestamp = Time.get_unix_time_from_system()
+	var post = {
+		"post_id": "v2_post_%d" % _next_post_id_v2,
+		"post_type": post_type_name,
+		"author_id": author_id,
+		"author_name": author_name,
+		"author_role": author_role,
+		"author_handle": _generate_handle(author_name),
+		"content": content,
+		"timestamp": timestamp,
+		"date_string": _get_date_string(),
+		"likes": int(extra.get("likes", 0)),
+		"player_liked": false,
+		"replies": [],
+		"event_type": extra.get("event_type", ""),
+		"mood": extra.get("mood", "neutral"),
+		"schema_version": V2_SCHEMA_VERSION,
+		"priority": int(extra.get("priority", _default_v2_priority(post_type_name, extra.get("event_type", "")))),
+		"tags": _to_string_array(extra.get("tags", [])),
+		"ranking_score": 0.0,
+		"ranking_reason": "",
+		"social_rep_eligible": bool(extra.get("social_rep_eligible", author_id == "player")),
+		"player_replied_in_thread": false
+	}
+
+	for key in ["score", "headline", "body", "source", "milestone_name"]:
+		if key in extra:
+			post[key] = extra[key]
+
+	_next_post_id_v2 += 1
+	_add_to_feed_v2(post)
+	return post
+
+
+func create_npc_post_v2(npc_id: String, content: String, event_type: String = "", mood: String = "neutral") -> Dictionary:
+	var npc_data = _get_npc_display_data(npc_id)
+	return create_post_v2(
+		POST_TYPE_NAMES[PostType.NPC_REACTION],
+		npc_id, npc_data.name, npc_data.role, content,
+		{
+			"event_type": event_type,
+			"mood": mood,
+			"likes": randi_range(5, 50),
+			"priority": 62,
+			"tags": ["npc", event_type]
+		}
+	)
+
+
+func create_player_post_v2(content: String) -> Dictionary:
+	var player_name = "You"
+	if GameManager.player_data:
+		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
+
+	var post = create_post_v2(
+		POST_TYPE_NAMES[PostType.PLAYER_POST],
+		"player", player_name, "player", content,
+		{"likes": randi_range(10, 80), "priority": 58, "tags": ["player", "thread"]}
+	)
+
+	_queue_npc_replies_v2(post.post_id, "player_post")
+	return post
+
+
+func add_reply_v2(parent_post_id: String, author_id: String, author_name: String,
+		author_role: String, content: String) -> Dictionary:
+	var reply = {
+		"post_id": "v2_reply_%d" % _next_post_id_v2,
+		"post_type": "reply",
+		"author_id": author_id,
+		"author_name": author_name,
+		"author_role": author_role,
+		"author_handle": _generate_handle(author_name),
+		"content": content,
+		"timestamp": Time.get_unix_time_from_system(),
+		"date_string": _get_date_string(),
+		"likes": 0,
+		"player_liked": false,
+		"schema_version": V2_SCHEMA_VERSION
+	}
+	_next_post_id_v2 += 1
+
+	for post in feed_v2:
+		if post.post_id == parent_post_id:
+			if post.replies.size() >= MAX_REPLIES_PER_POST:
+				return reply
+			post.replies.append(reply)
+			if author_id != "player":
+				_on_v2_npc_reply_added(post, reply)
+			_evaluate_v2_thread_engagement(post)
+			reply_added_v2.emit(parent_post_id, reply)
+			return reply
+
+	return reply
+
+
+func add_player_reply_v2(parent_post_id: String, content: String) -> Dictionary:
+	var player_name = "You"
+	if GameManager.player_data:
+		player_name = GameManager.player_data.name if GameManager.player_data.name != "" else "You"
+
+	var reply = add_reply_v2(parent_post_id, "player", player_name, "player", content)
+	var post = get_post_by_id_v2(parent_post_id)
+	if not post.is_empty():
+		post.player_replied_in_thread = true
+		_evaluate_v2_thread_engagement(post)
+	_queue_npc_replies_v2(parent_post_id, "player_post")
+	return reply
+
+
+func toggle_like_v2(post_id: String) -> void:
+	var post = get_post_by_id_v2(post_id)
+	if post.is_empty():
+		for p in feed_v2:
+			for r in p.replies:
+				if r.post_id == post_id:
+					r.player_liked = !r.player_liked
+					r.likes += 1 if r.player_liked else -1
+					return
+		return
+
+	post.player_liked = !post.player_liked
+	post.likes += 1 if post.player_liked else -1
+	_evaluate_v2_thread_engagement(post)
+
+
+func get_feed_v2(filter: String = "all", sort_mode: String = V2_SORT_TOP) -> Array[Dictionary]:
+	var filtered = _filter_v2_posts(filter)
+	var normalized_sort = sort_mode.to_lower()
+
+	if normalized_sort == V2_SORT_LATEST:
+		filtered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+			return _compare_v2_latest(a, b)
+		)
+		return filtered
+
+	for post in filtered:
+		var rank_data = _calculate_v2_rank(post)
+		post.ranking_score = rank_data.score
+		post.ranking_reason = rank_data.reason
+
+	filtered.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		var a_score = float(a.get("ranking_score", 0.0))
+		var b_score = float(b.get("ranking_score", 0.0))
+		if !is_equal_approx(a_score, b_score):
+			return a_score > b_score
+		return _compare_v2_latest(a, b)
+	)
+	return filtered
+
+
+func get_post_by_id_v2(post_id: String) -> Dictionary:
+	for post in feed_v2:
+		if post.post_id == post_id:
+			return post
+	return {}
+
+
+func on_match_ended_v2(result: Dictionary) -> void:
+	if not is_v2_enabled():
+		return
+
+	var normalized = _normalize_match_result_for_feed(result)
+	var player_team_name = normalized.player_team_name
+	var opponent_name = normalized.opponent_name
+	var player_score = normalized.player_score
+	var opponent_score = normalized.opponent_score
+	var score_str = "%d-%d" % [player_score, opponent_score]
+	var result_type = normalized.result_type
+	var mood = normalized.mood
+	var event_key = "match_" + result_type
+
+	var summary_content = "%s %s %s" % [player_team_name, score_str, opponent_name]
+	if result_type == "win":
+		summary_content += " - Victory!"
+	elif result_type == "loss":
+		summary_content += " - Defeat"
+	else:
+		summary_content += " - Draw"
+
+	create_post_v2(
+		POST_TYPE_NAMES[PostType.MATCH_SUMMARY],
+		"system", "Match Report", "system", summary_content,
+		{
+			"event_type": event_key,
+			"mood": mood,
+			"score": score_str,
+			"likes": randi_range(30, 150),
+			"priority": 84,
+			"tags": ["match", result_type, "summary"],
+			"social_rep_eligible": false
+		}
+	)
+
+	_generate_npc_event_posts_v2(event_key, mood, randi_range(2, 4))
+
+	var fan_count = randi_range(0, 2)
+	for i in range(fan_count):
+		var fan_templates = FAN_TEMPLATES.get(event_key, FAN_TEMPLATES["general"])
+		var fan_text = fan_templates[randi() % fan_templates.size()]
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.FAN_REACTION],
+			"fan_%d" % randi(), "Soccer Fan", "fan", fan_text,
+			{
+				"event_type": event_key,
+				"mood": mood,
+				"likes": randi_range(2, 20),
+				"priority": 48,
+				"tags": ["fan", result_type]
+			}
+		)
+
+	var news_list = NEWS_TEMPLATES.get(event_key, [])
+	if not news_list.is_empty():
+		var template = news_list[randi() % news_list.size()]
+		var headline = ""
+		var body = ""
+		match result_type:
+			"win":
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, opponent_name, score_str]
+			"loss":
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, score_str, opponent_name]
+			_:
+				headline = template.headline % [player_team_name, opponent_name]
+				body = template.body % [player_team_name, opponent_name, score_str]
+
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", "FanZone News", "news", headline,
+			{
+				"headline": headline,
+				"body": body,
+				"source": "FanZone Sports Desk",
+				"event_type": event_key,
+				"likes": randi_range(20, 100),
+				"priority": 78,
+				"tags": ["news", "match", result_type],
+				"social_rep_eligible": false
+			}
+		)
 
 
 # ─── NPC Text Generation ────────────────────────────────────────
@@ -636,6 +936,315 @@ func _process_reply_queue() -> void:
 		_reply_timer.start(_reply_queue[0].delay)
 
 
+func _queue_npc_replies_v2(parent_post_id: String, event_key: String) -> void:
+	var parent_post = get_post_by_id_v2(parent_post_id)
+	if parent_post.is_empty():
+		return
+
+	var npcs = _select_replying_npcs()
+	_cleanup_v2_reply_dedupe()
+	var now = Time.get_unix_time_from_system()
+	var last_npc = str(_v2_last_reply_npc_by_thread.get(parent_post_id, ""))
+
+	for i in range(npcs.size()):
+		var npc_id = npcs[i]
+		var dedupe_key = _generate_v2_reply_key(parent_post_id, npc_id)
+		if dedupe_key in _v2_recent_reply_keys and now - int(_v2_recent_reply_keys[dedupe_key]) < V2_REPLY_DEDUPE_WINDOW_SECONDS:
+			continue
+		if last_npc != "" and last_npc == npc_id:
+			continue
+
+		_reply_queue_v2.append({
+			"parent_post_id": parent_post_id,
+			"npc_id": npc_id,
+			"event_key": event_key,
+			"delay": 2.0 if i == 0 else randf_range(1.5, 3.0)
+		})
+		_v2_recent_reply_keys[dedupe_key] = now
+
+	if _reply_timer_v2 and not _reply_queue_v2.is_empty() and _reply_timer_v2.is_stopped():
+		_reply_timer_v2.start(float(_reply_queue_v2[0].delay))
+
+
+func _process_reply_queue_v2() -> void:
+	if not _reply_timer_v2:
+		return
+	if _reply_queue_v2.is_empty():
+		return
+
+	var item = _reply_queue_v2.pop_front()
+	var parent_post = get_post_by_id_v2(str(item.parent_post_id))
+	if parent_post.is_empty():
+		if not _reply_queue_v2.is_empty():
+			_reply_timer_v2.start(float(_reply_queue_v2[0].delay))
+		return
+
+	var npc_id = str(item.npc_id)
+	var last_npc = str(_v2_last_reply_npc_by_thread.get(parent_post.post_id, ""))
+	if last_npc != "" and last_npc == npc_id:
+		if not _reply_queue_v2.is_empty():
+			_reply_timer_v2.start(float(_reply_queue_v2[0].delay))
+		return
+
+	var npc_data = _get_npc_display_data(npc_id)
+	var text = _generate_npc_text(npc_id, str(item.event_key))
+	add_reply_v2(parent_post.post_id, npc_id, str(npc_data.name), str(npc_data.role), text)
+
+	if not _reply_queue_v2.is_empty():
+		_reply_timer_v2.start(float(_reply_queue_v2[0].delay))
+
+
+func _on_v2_npc_reply_added(parent_post: Dictionary, reply: Dictionary) -> void:
+	var parent_post_id = str(parent_post.get("post_id", ""))
+	_v2_last_reply_npc_by_thread[parent_post_id] = reply.get("author_id", "")
+
+	if parent_post.get("author_id", "") != "player":
+		return
+
+	if not _v2_first_npc_reply_awarded.get(parent_post_id, false):
+		if _grant_v2_social_reputation(1, "first_npc_reply"):
+			_v2_first_npc_reply_awarded[parent_post_id] = true
+
+	var day_key = _get_v2_day_key()
+	if str(_v2_notification_day_by_post.get(parent_post_id, "")) == day_key:
+		return
+
+	if DesktopManager:
+		DesktopManager.show_notification(
+			"FanZone Reply",
+			"%s replied to your post." % reply.get("author_name", "A teammate"),
+			"res://assets/ui/icons/icon_social.svg",
+			"social_media"
+		)
+	_v2_notification_day_by_post[parent_post_id] = day_key
+
+
+func _evaluate_v2_thread_engagement(post: Dictionary) -> void:
+	var post_id = str(post.get("post_id", ""))
+	if post_id == "":
+		return
+	if _v2_thread_engagement_awarded.get(post_id, false):
+		return
+	if not bool(post.get("player_replied_in_thread", false)):
+		return
+
+	var likes = int(post.get("likes", 0))
+	var npc_replies = _count_v2_npc_replies(post)
+	if likes < V2_THREAD_MIN_LIKES and npc_replies < V2_THREAD_MIN_NPC_REPLIES:
+		return
+
+	if _grant_v2_social_reputation(1, "thread_engagement"):
+		_v2_thread_engagement_awarded[post_id] = true
+
+
+func _count_v2_npc_replies(post: Dictionary) -> int:
+	var count = 0
+	for reply in post.get("replies", []):
+		if reply.get("author_id", "") != "player":
+			count += 1
+	return count
+
+
+func _grant_v2_social_reputation(delta: int, reason: String) -> bool:
+	if delta <= 0:
+		return false
+	_sync_v2_social_rep_day()
+	var remaining = maxi(V2_MAX_SOCIAL_REP_PER_DAY - _v2_social_rep_awarded_today, 0)
+	var applied = mini(delta, remaining)
+	if applied <= 0:
+		return false
+
+	if CareerManager and CareerManager.has_method("apply_social_reputation_delta"):
+		CareerManager.apply_social_reputation_delta(applied, reason)
+		_v2_social_rep_awarded_today += applied
+		return true
+	return false
+
+
+func _sync_v2_social_rep_day() -> void:
+	var day_key = _get_v2_day_key()
+	if _v2_social_rep_day_key == day_key:
+		return
+	_v2_social_rep_day_key = day_key
+	_v2_social_rep_awarded_today = 0
+
+
+func _get_v2_day_key() -> String:
+	if DesktopManager and DesktopManager.game_date:
+		var d = DesktopManager.game_date
+		return "%04d-%02d-%02d" % [int(d.get("year", 2024)), int(d.get("month", 1)), int(d.get("day", 1))]
+	var date = Time.get_date_dict_from_system()
+	return "%04d-%02d-%02d" % [int(date.get("year", 2024)), int(date.get("month", 1)), int(date.get("day", 1))]
+
+
+func _cleanup_v2_reply_dedupe() -> void:
+	var now = Time.get_unix_time_from_system()
+	var stale: Array[String] = []
+	for key in _v2_recent_reply_keys:
+		var ts = int(_v2_recent_reply_keys[key])
+		if now - ts >= V2_REPLY_DEDUPE_WINDOW_SECONDS:
+			stale.append(str(key))
+	for key in stale:
+		_v2_recent_reply_keys.erase(key)
+
+
+func _generate_v2_reply_key(parent_post_id: String, npc_id: String) -> String:
+	return "%s:%s" % [parent_post_id, npc_id]
+
+
+func _filter_v2_posts(filter: String) -> Array[Dictionary]:
+	if filter == "all":
+		var all_posts: Array[Dictionary] = []
+		all_posts.assign(feed_v2)
+		return all_posts
+
+	var filtered: Array[Dictionary] = []
+	for post in feed_v2:
+		match filter:
+			"npc":
+				if post.post_type == "npc_reaction":
+					filtered.append(post)
+			"news":
+				if post.post_type in ["news_article", "match_summary", "season_update", "injury_report"]:
+					filtered.append(post)
+			"my_posts":
+				if post.author_id == "player":
+					filtered.append(post)
+			"milestones":
+				if post.post_type == "milestone":
+					filtered.append(post)
+	return filtered
+
+
+func _compare_v2_latest(a: Dictionary, b: Dictionary) -> bool:
+	var a_ts = int(a.get("timestamp", 0))
+	var b_ts = int(b.get("timestamp", 0))
+	if a_ts != b_ts:
+		return a_ts > b_ts
+	return _extract_v2_id_num(str(a.get("post_id", ""))) > _extract_v2_id_num(str(b.get("post_id", "")))
+
+
+func _extract_v2_id_num(id_str: String) -> int:
+	var parts = id_str.split("_")
+	if parts.is_empty():
+		return 0
+	var tail = parts[-1]
+	return int(tail) if tail.is_valid_int() else 0
+
+
+func _calculate_v2_rank(post: Dictionary) -> Dictionary:
+	var now = Time.get_unix_time_from_system()
+	var timestamp = int(post.get("timestamp", now))
+	var age_hours = maxf(0.0, float(now - timestamp) / 3600.0)
+	var recency = 100.0 * pow(0.5, age_hours / V2_RECENCY_HALFLIFE_HOURS)
+
+	var likes = int(post.get("likes", 0))
+	var reply_count = post.get("replies", []).size()
+	var engagement = minf(100.0, likes * 4.0 + reply_count * 12.0)
+
+	var priority = clampf(float(post.get("priority", 40)), 0.0, 100.0)
+
+	var boosts = 0.0
+	var event_type = str(post.get("event_type", ""))
+	var post_type = str(post.get("post_type", ""))
+	if post_type == "milestone" or event_type in ["qualification", "national_champion", "milestone"]:
+		boosts += 8.0
+	if post_type == "match_summary":
+		boosts += 6.0
+	if reply_count >= 3:
+		boosts += 5.0
+
+	var score = (0.45 * recency) + (0.35 * engagement) + (0.20 * priority) + boosts
+	var reason = "Balanced relevance"
+	if boosts >= 8.0:
+		reason = "Major event boost"
+	elif reply_count >= 3:
+		reason = "Active discussion thread"
+	elif recency >= engagement and recency >= priority:
+		reason = "Fresh post momentum"
+	elif engagement >= recency and engagement >= priority:
+		reason = "High engagement"
+	else:
+		reason = "High priority story"
+
+	return {"score": score, "reason": reason}
+
+
+func _normalize_match_result_for_feed(result: Dictionary) -> Dictionary:
+	var player_team_name = "Our Team"
+	if GameManager.current_team:
+		player_team_name = GameManager.current_team.name
+	if result.has("player_team"):
+		player_team_name = str(result.get("player_team", player_team_name))
+
+	var opponent_name = str(result.get("opponent_name", result.get("opponent", "Opponent")))
+	var player_score = 0
+	var opponent_score = 0
+
+	if result.has("player_score") and result.has("opponent_score"):
+		player_score = int(result.get("player_score", 0))
+		opponent_score = int(result.get("opponent_score", 0))
+	elif result.has("home_score") and result.has("away_score"):
+		var is_home = bool(result.get("is_home", true))
+		var home_score = int(result.get("home_score", 0))
+		var away_score = int(result.get("away_score", 0))
+		player_score = home_score if is_home else away_score
+		opponent_score = away_score if is_home else home_score
+	else:
+		player_score = int(result.get("goals_for", 0))
+		opponent_score = int(result.get("goals_against", 0))
+
+	var result_type = "draw"
+	var mood = "neutral"
+	if player_score > opponent_score:
+		result_type = "win"
+		mood = "happy"
+	elif player_score < opponent_score:
+		result_type = "loss"
+		mood = "sad"
+
+	return {
+		"player_team_name": player_team_name,
+		"opponent_name": opponent_name,
+		"player_score": player_score,
+		"opponent_score": opponent_score,
+		"result_type": result_type,
+		"mood": mood
+	}
+
+
+func _default_v2_priority(post_type_name: String, event_type: String) -> int:
+	match post_type_name:
+		"milestone":
+			return 90
+		"match_summary":
+			return 85
+		"news_article":
+			return 75
+		"season_update":
+			return 70
+		"injury_report":
+			return 68
+		"player_post":
+			return 58
+		"npc_reaction":
+			return 62
+		"fan_reaction":
+			return 48
+		_:
+			if event_type == "qualification":
+				return 90
+			return 50
+
+
+func _to_string_array(value: Variant) -> Array[String]:
+	var output: Array[String] = []
+	if value is Array:
+		for item in value:
+			output.append(str(item))
+	return output
+
+
 # ─── Event Handlers ──────────────────────────────────────────────
 
 func on_match_ended(result: Dictionary) -> void:
@@ -732,6 +1341,20 @@ func _on_phase_changed(new_phase: int) -> void:
 		{"event_type": "phase_changed", "mood": "excited", "likes": randi_range(15, 60)}
 	)
 
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.SEASON_UPDATE],
+			"system", "Season Update", "system",
+			"The %s has begun! A new chapter of our journey starts now." % phase_name,
+			{
+				"event_type": "phase_changed",
+				"mood": "excited",
+				"likes": randi_range(15, 60),
+				"priority": 70,
+				"tags": ["season", "phase"]
+			}
+		)
+
 
 func _on_standings_updated(_standings: Array[Dictionary]) -> void:
 	pass  # Could add periodic standings update posts
@@ -777,6 +1400,55 @@ func _on_qualified_for_nationals() -> void:
 			 "likes": randi_range(50, 200)}
 		)
 
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.MILESTONE],
+			"system", "Achievement", "system",
+			"QUALIFIED FOR NATIONALS! %s is heading to the National Championship!" % team_name,
+			{
+				"event_type": "qualification",
+				"mood": "ecstatic",
+				"milestone_name": "National Qualification",
+				"likes": randi_range(100, 300),
+				"priority": 92,
+				"tags": ["milestone", "qualification", "nationals"],
+				"social_rep_eligible": false
+			}
+		)
+		_generate_npc_event_posts_v2("milestone", "ecstatic", randi_range(3, 5))
+		var fan_templates_v2 = FAN_TEMPLATES["milestone"]
+		for i in range(randi_range(2, 3)):
+			create_post_v2(
+				POST_TYPE_NAMES[PostType.FAN_REACTION],
+				"fan_%d" % randi(), "Excited Fan", "fan",
+				fan_templates_v2[randi() % fan_templates_v2.size()],
+				{
+					"event_type": "qualification",
+					"mood": "ecstatic",
+					"likes": randi_range(10, 50),
+					"priority": 52,
+					"tags": ["fan", "qualification"]
+				}
+			)
+
+		if not news_list.is_empty():
+			var template_v2 = news_list[randi() % news_list.size()]
+			create_post_v2(
+				POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+				"news", "FanZone News", "news",
+				template_v2.headline % team_name,
+				{
+					"headline": template_v2.headline % team_name,
+					"body": template_v2.body % team_name,
+					"source": "FanZone Sports Desk",
+					"event_type": "qualification",
+					"likes": randi_range(50, 200),
+					"priority": 88,
+					"tags": ["news", "qualification"],
+					"social_rep_eligible": false
+				}
+			)
+
 
 func _on_season_completed(summary: Dictionary) -> void:
 	var team_name = "Our Team"
@@ -803,6 +1475,38 @@ func _on_season_completed(summary: Dictionary) -> void:
 			 "likes": randi_range(30, 120)}
 		)
 
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.SEASON_UPDATE],
+			"system", "Season Update", "system",
+			"The season has come to an end for %s. What a journey it's been!" % team_name,
+			{
+				"event_type": "season_end",
+				"mood": "reflective",
+				"likes": randi_range(30, 100),
+				"priority": 74,
+				"tags": ["season", "wrapup"],
+				"social_rep_eligible": false
+			}
+		)
+		if not news_list.is_empty():
+			var template_v2 = news_list[randi() % news_list.size()]
+			create_post_v2(
+				POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+				"news", "FanZone News", "news",
+				template_v2.headline % team_name,
+				{
+					"headline": template_v2.headline % team_name,
+					"body": template_v2.body % team_name,
+					"source": "FanZone Sports Desk",
+					"event_type": "season_end",
+					"likes": randi_range(30, 120),
+					"priority": 76,
+					"tags": ["news", "season_end"],
+					"social_rep_eligible": false
+				}
+			)
+
 
 func _on_milestone_reached(milestone: String) -> void:
 	var player_name = "Our Star"
@@ -819,6 +1523,23 @@ func _on_milestone_reached(milestone: String) -> void:
 
 	# NPC congratulations (1-2)
 	_generate_npc_event_posts("milestone", "proud", randi_range(1, 2))
+
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.MILESTONE],
+			"system", "Achievement", "system",
+			"%s reached a new milestone: %s!" % [player_name, milestone.replace("_", " ").capitalize()],
+			{
+				"event_type": "milestone",
+				"mood": "proud",
+				"milestone_name": milestone,
+				"likes": randi_range(40, 150),
+				"priority": 90,
+				"tags": ["milestone", milestone],
+				"social_rep_eligible": false
+			}
+		)
+		_generate_npc_event_posts_v2("milestone", "proud", randi_range(1, 2))
 
 
 func _on_npc_injured(npc_id: String, injury: Dictionary) -> void:
@@ -839,6 +1560,25 @@ func _on_npc_injured(npc_id: String, injury: Dictionary) -> void:
 	# Get-well NPC posts (1-2)
 	_generate_npc_injury_posts(npc_id, randi_range(1, 2))
 
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.INJURY_REPORT],
+			"system", "Medical Update", "system",
+			"%s has suffered a %s and will miss %d match%s." % [
+				npc_data.name, description, matches_out,
+				"es" if matches_out != 1 else ""
+			],
+			{
+				"event_type": "injury",
+				"mood": "concerned",
+				"likes": randi_range(10, 40),
+				"priority": 72,
+				"tags": ["injury", "medical"],
+				"social_rep_eligible": false
+			}
+		)
+		_generate_npc_injury_posts_v2(npc_id, randi_range(1, 2))
+
 
 func _on_npc_recovered(npc_id: String) -> void:
 	var npc_data = _get_npc_display_data(npc_id)
@@ -853,6 +1593,21 @@ func _on_npc_recovered(npc_id: String) -> void:
 	# Welcome-back posts (1-2)
 	_generate_npc_recovery_posts(npc_id, randi_range(1, 2))
 
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.NPC_REACTION],
+			npc_id, npc_data.name, npc_data.role,
+			"I'm back! Feeling good and ready to play again!",
+			{
+				"event_type": "recovery",
+				"mood": "happy",
+				"likes": randi_range(15, 60),
+				"priority": 66,
+				"tags": ["recovery", "npc"]
+			}
+		)
+		_generate_npc_recovery_posts_v2(npc_id, randi_range(1, 2))
+
 
 func _on_narrative_news_article(article: Dictionary) -> void:
 	create_post(
@@ -864,6 +1619,22 @@ func _on_narrative_news_article(article: Dictionary) -> void:
 		 "source": article.get("author", "FanZone"),
 		 "likes": randi_range(20, 100)}
 	)
+
+	if is_v2_enabled():
+		create_post_v2(
+			POST_TYPE_NAMES[PostType.NEWS_ARTICLE],
+			"news", article.get("author", "FanZone"), "news",
+			article.get("headline", "News Update"),
+			{
+				"headline": article.get("headline", "News Update"),
+				"body": article.get("body", ""),
+				"source": article.get("author", "FanZone"),
+				"likes": randi_range(20, 100),
+				"priority": 74,
+				"tags": ["news", "narrative"],
+				"social_rep_eligible": false
+			}
+		)
 
 
 # ─── NPC Post Generation Helpers ────────────────────────────────
@@ -879,6 +1650,17 @@ func _generate_npc_event_posts(event_key: String, mood: String, count: int) -> v
 		create_npc_post(npc_id, text, event_key, mood)
 
 
+func _generate_npc_event_posts_v2(event_key: String, mood: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var npc_id = npcs[i]
+		var text = _generate_npc_text(npc_id, event_key)
+		create_npc_post_v2(npc_id, text, event_key, mood)
+
+
 func _generate_npc_injury_posts(injured_npc_id: String, count: int) -> void:
 	var npcs = _get_available_teammate_npcs()
 	npcs.erase(injured_npc_id)
@@ -890,6 +1672,17 @@ func _generate_npc_injury_posts(injured_npc_id: String, count: int) -> void:
 		create_npc_post(npcs[i], text, "injury", "concerned")
 
 
+func _generate_npc_injury_posts_v2(injured_npc_id: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.erase(injured_npc_id)
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var text = _generate_npc_text(npcs[i], "injury_teammate")
+		create_npc_post_v2(npcs[i], text, "injury", "concerned")
+
+
 func _generate_npc_recovery_posts(recovered_npc_id: String, count: int) -> void:
 	var npcs = _get_available_teammate_npcs()
 	npcs.erase(recovered_npc_id)
@@ -899,6 +1692,17 @@ func _generate_npc_recovery_posts(recovered_npc_id: String, count: int) -> void:
 	for i in range(actual_count):
 		var text = _generate_npc_text(npcs[i], "recovery")
 		create_npc_post(npcs[i], text, "recovery", "happy")
+
+
+func _generate_npc_recovery_posts_v2(recovered_npc_id: String, count: int) -> void:
+	var npcs = _get_available_teammate_npcs()
+	npcs.erase(recovered_npc_id)
+	npcs.shuffle()
+	var actual_count = mini(count, npcs.size())
+
+	for i in range(actual_count):
+		var text = _generate_npc_text(npcs[i], "recovery")
+		create_npc_post_v2(npcs[i], text, "recovery", "happy")
 
 
 func _get_available_teammate_npcs() -> Array[String]:
@@ -918,6 +1722,13 @@ func _add_to_feed(post: Dictionary) -> void:
 	if feed.size() > MAX_FEED_SIZE:
 		feed.resize(MAX_FEED_SIZE)
 	post_added.emit(post)
+
+
+func _add_to_feed_v2(post: Dictionary) -> void:
+	feed_v2.insert(0, post)
+	if feed_v2.size() > MAX_FEED_SIZE:
+		feed_v2.resize(MAX_FEED_SIZE)
+	post_added_v2.emit(post)
 
 
 func _generate_handle(author_name: String) -> String:
@@ -957,12 +1768,67 @@ func ensure_welcome_post() -> void:
 func to_dict() -> Dictionary:
 	return {
 		"feed": feed,
-		"next_post_id": _next_post_id
+		"next_post_id": _next_post_id,
+		"feed_v2": feed_v2,
+		"next_post_id_v2": _next_post_id_v2,
+		"v2_social_rep_day_key": _v2_social_rep_day_key,
+		"v2_social_rep_awarded_today": _v2_social_rep_awarded_today,
+		"v2_first_npc_reply_awarded": _v2_first_npc_reply_awarded,
+		"v2_thread_engagement_awarded": _v2_thread_engagement_awarded,
+		"v2_notification_day_by_post": _v2_notification_day_by_post
 	}
 
 
 func from_dict(data: Dictionary) -> void:
 	feed.assign(data.get("feed", []))
 	_next_post_id = data.get("next_post_id", feed.size() + 1)
+
+	if data.has("feed_v2"):
+		feed_v2.assign(data.get("feed_v2", []))
+	else:
+		feed_v2 = _bootstrap_v2_from_v1(feed)
+
+	if feed_v2.is_empty() and not feed.is_empty() and not data.has("feed_v2"):
+		feed_v2 = _bootstrap_v2_from_v1(feed)
+
+	for post in feed_v2:
+		_ensure_v2_post_defaults(post)
+
+	_next_post_id_v2 = data.get("next_post_id_v2", feed_v2.size() + 1)
+	_v2_social_rep_day_key = str(data.get("v2_social_rep_day_key", _get_v2_day_key()))
+	_v2_social_rep_awarded_today = int(data.get("v2_social_rep_awarded_today", 0))
+	_v2_first_npc_reply_awarded = data.get("v2_first_npc_reply_awarded", {})
+	_v2_thread_engagement_awarded = data.get("v2_thread_engagement_awarded", {})
+	_v2_notification_day_by_post = data.get("v2_notification_day_by_post", {})
+
 	feed_refreshed.emit()
-	print("[SocialFeedManager] Loaded %d posts from save" % feed.size())
+	feed_refreshed_v2.emit()
+	print("[SocialFeedManager] Loaded %d V1 posts and %d V2 posts from save" % [feed.size(), feed_v2.size()])
+
+
+func _bootstrap_v2_from_v1(source_feed: Array[Dictionary]) -> Array[Dictionary]:
+	var bootstrapped: Array[Dictionary] = []
+	for source_post in source_feed:
+		var post = source_post.duplicate(true)
+		post["post_id"] = "v2_post_%d" % _extract_v2_id_num(str(post.get("post_id", "0")).replace("post_", ""))
+		if str(post.post_id) == "v2_post_0":
+			post["post_id"] = "v2_post_%d" % (_next_post_id_v2 + bootstrapped.size())
+		post["schema_version"] = V2_SCHEMA_VERSION
+		post["priority"] = _default_v2_priority(str(post.get("post_type", "")), str(post.get("event_type", "")))
+		post["tags"] = _to_string_array(post.get("tags", [str(post.get("post_type", "post"))]))
+		post["ranking_score"] = 0.0
+		post["ranking_reason"] = ""
+		post["social_rep_eligible"] = bool(post.get("author_id", "") == "player")
+		post["player_replied_in_thread"] = false
+		bootstrapped.append(post)
+	return bootstrapped
+
+
+func _ensure_v2_post_defaults(post: Dictionary) -> void:
+	post["schema_version"] = int(post.get("schema_version", V2_SCHEMA_VERSION))
+	post["priority"] = int(post.get("priority", _default_v2_priority(str(post.get("post_type", "")), str(post.get("event_type", "")))))
+	post["tags"] = _to_string_array(post.get("tags", []))
+	post["ranking_score"] = float(post.get("ranking_score", 0.0))
+	post["ranking_reason"] = str(post.get("ranking_reason", ""))
+	post["social_rep_eligible"] = bool(post.get("social_rep_eligible", post.get("author_id", "") == "player"))
+	post["player_replied_in_thread"] = bool(post.get("player_replied_in_thread", false))

--- a/scripts/training/freekick_drill.gd
+++ b/scripts/training/freekick_drill.gd
@@ -1,25 +1,24 @@
-extends Control
+extends TrainingDrillBase
 ## FreekickDrill - Free kick training mini-game
 ## Features 3x3 goal targeting, defensive wall, curve mechanics, power charging, and skill checks
 
-signal drill_completed(results: Dictionary)
 
 # Static function for simulating rewards without playing
 static func calculate_simulated_rewards(goals: int, attempts: int = 10) -> Dictionary:
-	var total_xp = XP_PER_ATTEMPT * attempts
+	var total_xp = TrainingConstants.XP_PER_ATTEMPT * attempts
 	total_xp += XP_PER_GOAL * goals
 
 	# Estimate bonus XP based on score
-	var top_corner_bonus = roundi(goals * 0.3) * XP_TOP_CORNER_BONUS  # Assume 30% top corners
-	var curve_bonus = roundi(goals * 0.5) * XP_CURVE_GOAL_BONUS  # Assume 50% used correct curve
+	var top_corner_bonus = roundi(goals * 0.3) * XP_TOP_CORNER_BONUS
+	var curve_bonus = roundi(goals * 0.5) * XP_CURVE_GOAL_BONUS
 	total_xp += top_corner_bonus + curve_bonus
 
 	if goals >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
+		total_xp += TrainingConstants.XP_GOOD_SESSION_BONUS
 	if goals >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
+		total_xp += TrainingConstants.XP_PERFECT_SESSION_BONUS
 
-	var sho_xp = (STAT_XP_PER_GOAL * goals) + (STAT_XP_PER_MISS * (attempts - goals))
+	var sho_xp = (TrainingConstants.STAT_XP_PER_SUCCESS * goals) + (TrainingConstants.STAT_XP_PER_FAIL * (attempts - goals))
 	var tec_xp = TEC_XP_PER_ATTEMPT * attempts
 
 	return {
@@ -28,7 +27,7 @@ static func calculate_simulated_rewards(goals: int, attempts: int = 10) -> Dicti
 		"total_xp": total_xp,
 		"sho_xp": sho_xp,
 		"tec_xp": tec_xp,
-		"stamina_cost": STAMINA_COST
+		"stamina_cost": TrainingConstants.STAMINA_COST
 	}
 
 
@@ -42,30 +41,14 @@ enum DrillState {
 	DRILL_COMPLETE
 }
 
-enum WallPosition {
-	LEFT,
-	CENTER,
-	RIGHT
-}
-
-enum CurveDirection {
-	LEFT_SWERVE,
-	STRAIGHT,
-	RIGHT_SWERVE
-}
+enum WallPosition { LEFT, CENTER, RIGHT }
+enum CurveDirection { LEFT_SWERVE, STRAIGHT, RIGHT_SWERVE }
 
 # Difficulty settings
 const DIFFICULTY_SETTINGS: Dictionary = {
 	"youth": {"name": "20 yards", "distance": 20, "wall_size": 3, "base_mod": 5, "gk_stat": 35, "unlocked": true},
 	"pro": {"name": "25 yards", "distance": 25, "wall_size": 4, "base_mod": 0, "gk_stat": 55, "unlocked": false},
 	"elite": {"name": "30 yards", "distance": 30, "wall_size": 4, "base_mod": -10, "gk_stat": 75, "unlocked": false}
-}
-
-# Zone modifiers (same as penalty)
-const ZONE_MODIFIERS: Dictionary = {
-	"TOP_LEFT": -20, "TOP_CENTER": -15, "TOP_RIGHT": -20,
-	"MID_LEFT": -10, "MID_CENTER": 5, "MID_RIGHT": -10,
-	"LOW_LEFT": -10, "LOW_CENTER": -5, "LOW_RIGHT": -10
 }
 
 # Wall blocking - which zones are blocked by each wall position
@@ -90,46 +73,11 @@ const CENTER_ZONES: Array[String] = ["TOP_CENTER", "MID_CENTER", "LOW_CENTER"]
 const RIGHT_ZONES: Array[String] = ["TOP_RIGHT", "MID_RIGHT", "LOW_RIGHT"]
 const TOP_CORNER_ZONES: Array[String] = ["TOP_LEFT", "TOP_RIGHT"]
 
-# Power modifiers
-const POWER_RANGES: Array[Dictionary] = [
-	{"min": 0, "max": 39, "name": "Weak", "modifier": -15},
-	{"min": 40, "max": 69, "name": "Good", "modifier": 0},
-	{"min": 70, "max": 85, "name": "Optimal", "modifier": 5},
-	{"min": 86, "max": 100, "name": "Overpowered", "modifier": -10}
-]
-
-# XP rewards
-const XP_PER_ATTEMPT: int = 5
+# Drill-specific XP rewards
 const XP_PER_GOAL: int = 10
 const XP_TOP_CORNER_BONUS: int = 5
 const XP_CURVE_GOAL_BONUS: int = 3
-const XP_GOOD_SESSION_BONUS: int = 25  # 7+ goals
-const XP_PERFECT_SESSION_BONUS: int = 50  # 10/10
-const STAT_XP_PER_GOAL: int = 3
-const STAT_XP_PER_MISS: int = 1
 const TEC_XP_PER_ATTEMPT: int = 2
-const STAMINA_COST: int = 15
-const FREEKICKS_PER_SESSION: int = 10
-const CHARGE_RATE: float = 66.67  # 100% in 1.5 seconds
-
-# Console Dashboard Colors
-const BG_DARK = Color(0.039, 0.086, 0.157)
-const PANEL_BG = Color(0.06, 0.1, 0.18, 0.95)
-const BORDER_COLOR = Color(0.15, 0.25, 0.4)
-const ACCENT_GREEN = Color(0, 1, 0.5)
-const TEXT_PRIMARY = Color(0.9, 0.95, 1)
-const TEXT_SECONDARY = Color(0.6, 0.65, 0.7)
-const TEXT_MUTED = Color(0.5, 0.55, 0.6)
-
-# State Colors
-const COLOR_DEFAULT = Color(0.1, 0.15, 0.25)
-const COLOR_SELECTED = Color(0, 0.6, 0.3)
-const COLOR_SUCCESS = Color(0, 0.8, 0.4)
-const COLOR_FAIL = Color(0.8, 0.3, 0.3)
-const COLOR_WARNING = Color(0.9, 0.7, 0.2)
-const COLOR_BLOCKED = Color(0.6, 0.2, 0.2)
-const COLOR_CONTESTED = Color(0.8, 0.5, 0.2)
-const COLOR_OPEN = Color(0.2, 0.5, 0.8)
 
 # Node references
 @onready var difficulty_selector: OptionButton = $VBoxContainer/HeaderSection/DifficultyContainer/DifficultySelector
@@ -158,19 +106,15 @@ const COLOR_OPEN = Color(0.2, 0.5, 0.8)
 
 # State
 var current_state: DrillState = DrillState.SETUP
-var current_difficulty: String = "youth"
 var selected_zone: String = ""
 var selected_curve: CurveDirection = CurveDirection.STRAIGHT
 var current_wall_position: WallPosition = WallPosition.CENTER
 var current_power: float = 0.0
 var is_charging: bool = false
 
-# Session tracking
-var attempts_taken: int = 0
-var goals_scored: int = 0
+# Session tracking (additional to base class)
 var top_corner_goals: int = 0
 var curve_goals: int = 0
-var session_results: Array[Dictionary] = []
 
 # Zone button references
 var zone_buttons: Dictionary = {}
@@ -178,47 +122,78 @@ var curve_buttons: Array[Button] = []
 var wall_blocks: Array[Panel] = []
 
 
+# ===== OVERRIDES =====
+
+func _get_drill_name() -> String:
+	return "freekick"
+
+
+func _get_primary_stat() -> String:
+	return "SHO"
+
+
+func _get_secondary_stat() -> String:
+	return "TEC"
+
+
+func _get_difficulty_settings() -> Dictionary:
+	return DIFFICULTY_SETTINGS
+
+
+func _get_xp_per_success() -> int:
+	return XP_PER_GOAL
+
+
+func _get_success_label() -> String:
+	return "Goals"
+
+
+func _is_drill_complete() -> bool:
+	return current_state == DrillState.DRILL_COMPLETE
+
+
+func _get_completion_title() -> String:
+	return "Free Kick Practice Complete"
+
+
+func _calculate_bonus_xp() -> int:
+	return (XP_TOP_CORNER_BONUS * top_corner_goals) + (XP_CURVE_GOAL_BONUS * curve_goals)
+
+
+func _get_bonus_xp_breakdown() -> String:
+	var breakdown = ""
+	if top_corner_goals > 0:
+		breakdown += "Top Corners: +%d XP (%d × %d)\n" % [XP_TOP_CORNER_BONUS * top_corner_goals, top_corner_goals, XP_TOP_CORNER_BONUS]
+	if curve_goals > 0:
+		breakdown += "Curve Goals: +%d XP (%d × %d)\n" % [XP_CURVE_GOAL_BONUS * curve_goals, curve_goals, XP_CURVE_GOAL_BONUS]
+	return breakdown
+
+
+func _calculate_secondary_stat_xp(_xp_per_attempt: int = 2) -> int:
+	return TEC_XP_PER_ATTEMPT * attempts_taken
+
+
+# ===== SETUP =====
+
 func _ready() -> void:
-	_setup_difficulty_selector()
+	_setup_difficulty_selector(difficulty_selector)
 	_setup_zone_buttons()
 	_setup_curve_buttons()
 	_setup_wall_indicator()
 	_setup_signals()
-	_style_footer_buttons()
+	_style_footer_buttons(continue_button, exit_button)
+	_style_shoot_button(shoot_button)
 	_update_player_stats_display()
 	_generate_new_wall_position()
 	_set_state(DrillState.SELECTING_ZONE)
-	_show_session_start_narration()
-
-
-func _setup_difficulty_selector() -> void:
-	difficulty_selector.clear()
-	var idx = 0
-	for diff_id in DIFFICULTY_SETTINGS:
-		var diff = DIFFICULTY_SETTINGS[diff_id]
-		var text = diff.name
-		if not diff.unlocked:
-			text += " (Locked)"
-		difficulty_selector.add_item(text, idx)
-		if not diff.unlocked:
-			difficulty_selector.set_item_disabled(idx, true)
-		idx += 1
-	difficulty_selector.selected = 0
-	difficulty_selector.item_selected.connect(_on_difficulty_changed)
+	_show_session_start_narration(narration_label)
 
 
 func _setup_zone_buttons() -> void:
-	var zone_names = ["TOP_LEFT", "TOP_CENTER", "TOP_RIGHT",
-					  "MID_LEFT", "MID_CENTER", "MID_RIGHT",
-					  "LOW_LEFT", "LOW_CENTER", "LOW_RIGHT"]
-	var button_names = ["TopLeft", "TopCenter", "TopRight",
-						"MidLeft", "MidCenter", "MidRight",
-						"LowLeft", "LowCenter", "LowRight"]
-
-	for i in range(zone_names.size()):
-		var btn = zone_grid.get_node(button_names[i])
-		zone_buttons[zone_names[i]] = btn
-		btn.pressed.connect(_on_zone_selected.bind(zone_names[i]))
+	for i in range(TrainingConstants.ZONE_NAMES.size()):
+		var btn = zone_grid.get_node(TrainingConstants.ZONE_BUTTON_NAMES[i])
+		zone_buttons[TrainingConstants.ZONE_NAMES[i]] = btn
+		btn.pressed.connect(_on_zone_selected.bind(TrainingConstants.ZONE_NAMES[i]))
 
 
 func _setup_curve_buttons() -> void:
@@ -234,7 +209,6 @@ func _setup_curve_buttons() -> void:
 
 
 func _setup_wall_indicator() -> void:
-	# Store references to wall block panels
 	for i in range(4):
 		var block = wall_indicator.get_node("WallBlock%d" % (i + 1))
 		wall_blocks.append(block)
@@ -245,74 +219,6 @@ func _setup_signals() -> void:
 	continue_button.pressed.connect(_on_continue_pressed)
 	exit_button.pressed.connect(_on_exit_pressed)
 	charge_timer.timeout.connect(_on_charge_tick)
-
-
-func _style_footer_buttons() -> void:
-	# Style Continue button with console green accent
-	var continue_style = StyleBoxFlat.new()
-	continue_style.bg_color = Color(0, 0.6, 0.3)
-	continue_style.border_width_left = 2
-	continue_style.border_width_top = 2
-	continue_style.border_width_right = 2
-	continue_style.border_width_bottom = 2
-	continue_style.border_color = Color(0, 0.8, 0.4)
-	continue_style.set_corner_radius_all(6)
-	continue_button.add_theme_stylebox_override("normal", continue_style)
-	continue_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var continue_hover = continue_style.duplicate()
-	continue_hover.bg_color = Color(0, 0.7, 0.35)
-	continue_button.add_theme_stylebox_override("hover", continue_hover)
-
-	var continue_pressed = continue_style.duplicate()
-	continue_pressed.bg_color = Color(0, 0.5, 0.25)
-	continue_button.add_theme_stylebox_override("pressed", continue_pressed)
-
-	# Style Exit button with dark panel style
-	var exit_style = StyleBoxFlat.new()
-	exit_style.bg_color = COLOR_DEFAULT
-	exit_style.border_width_left = 2
-	exit_style.border_width_top = 2
-	exit_style.border_width_right = 2
-	exit_style.border_width_bottom = 2
-	exit_style.border_color = BORDER_COLOR
-	exit_style.set_corner_radius_all(6)
-	exit_button.add_theme_stylebox_override("normal", exit_style)
-	exit_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var exit_hover = exit_style.duplicate()
-	exit_hover.bg_color = Color(0.15, 0.2, 0.3)
-	exit_button.add_theme_stylebox_override("hover", exit_hover)
-
-	var exit_pressed = exit_style.duplicate()
-	exit_pressed.bg_color = Color(0.08, 0.12, 0.2)
-	exit_button.add_theme_stylebox_override("pressed", exit_pressed)
-
-	# Style Shoot button with console theme
-	var shoot_style = StyleBoxFlat.new()
-	shoot_style.bg_color = COLOR_DEFAULT
-	shoot_style.border_width_left = 2
-	shoot_style.border_width_top = 2
-	shoot_style.border_width_right = 2
-	shoot_style.border_width_bottom = 2
-	shoot_style.border_color = ACCENT_GREEN
-	shoot_style.set_corner_radius_all(6)
-	shoot_button.add_theme_stylebox_override("normal", shoot_style)
-	shoot_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var shoot_hover = shoot_style.duplicate()
-	shoot_hover.bg_color = Color(0.15, 0.2, 0.3)
-	shoot_button.add_theme_stylebox_override("hover", shoot_hover)
-
-	var shoot_pressed = shoot_style.duplicate()
-	shoot_pressed.bg_color = Color(0, 0.5, 0.25)
-	shoot_button.add_theme_stylebox_override("pressed", shoot_pressed)
-
-	var shoot_disabled = shoot_style.duplicate()
-	shoot_disabled.bg_color = Color(0.08, 0.1, 0.15)
-	shoot_disabled.border_color = Color(0.2, 0.25, 0.35)
-	shoot_button.add_theme_stylebox_override("disabled", shoot_disabled)
-	shoot_button.add_theme_color_override("font_disabled_color", TEXT_MUTED)
 
 
 func _update_player_stats_display() -> void:
@@ -333,8 +239,9 @@ func _calculate_base_chance(sho: int, tec: int) -> float:
 	return (sho * 0.6) + (tec * 0.4)
 
 
+# ===== WALL MECHANICS =====
+
 func _generate_new_wall_position() -> void:
-	# Randomly choose wall position
 	current_wall_position = randi() % 3 as WallPosition
 	_update_wall_display()
 	_update_zone_blocking_display()
@@ -344,21 +251,9 @@ func _update_wall_display() -> void:
 	var diff = DIFFICULTY_SETTINGS[current_difficulty]
 	var wall_size = diff.wall_size
 
-	# Show/hide wall blocks based on wall size
 	for i in range(wall_blocks.size()):
 		wall_blocks[i].visible = i < wall_size
 
-	# Position wall blocks based on wall position
-	var base_offset = 0
-	match current_wall_position:
-		WallPosition.LEFT:
-			base_offset = 0
-		WallPosition.CENTER:
-			base_offset = 1
-		WallPosition.RIGHT:
-			base_offset = 2
-
-	# Update wall indicator alignment
 	match current_wall_position:
 		WallPosition.LEFT:
 			wall_indicator.alignment = BoxContainer.ALIGNMENT_BEGIN
@@ -373,15 +268,15 @@ func _update_zone_blocking_display() -> void:
 
 	for zone in zone_buttons:
 		var btn = zone_buttons[zone]
-		var base_color = COLOR_DEFAULT
-		var border_color = BORDER_COLOR
+		var base_color = TrainingConstants.COLOR_DEFAULT
+		var border_color = TrainingConstants.BORDER_COLOR
 
 		if zone in blocking.full:
-			border_color = COLOR_BLOCKED  # Red - fully blocked
+			border_color = TrainingConstants.COLOR_BLOCKED
 		elif zone in blocking.partial:
-			border_color = COLOR_WARNING  # Amber - partially blocked
+			border_color = TrainingConstants.COLOR_WARNING
 		else:
-			border_color = COLOR_OPEN  # Blue - clear
+			border_color = TrainingConstants.COLOR_OPEN
 
 		_set_zone_button_style(zone, base_color, border_color)
 
@@ -390,15 +285,17 @@ func _get_wall_modifier(zone: String) -> int:
 	var blocking = WALL_BLOCKING[current_wall_position]
 
 	if zone in blocking.full:
-		return -30  # Fully blocked
+		return -30
 	elif zone in blocking.partial:
-		return -15  # Partially blocked
+		return -15
 	else:
-		return 5  # Clear shot
+		return 5
 
+
+# ===== CURVE MECHANICS =====
 
 func _get_curve_modifier(target_zone: String, curve: CurveDirection, tec: int) -> int:
-	var tec_factor = tec / 100.0  # Scale by technique
+	var tec_factor = tec / 100.0
 
 	if curve == CurveDirection.STRAIGHT:
 		return 0
@@ -409,21 +306,18 @@ func _get_curve_modifier(target_zone: String, curve: CurveDirection, tec: int) -
 	elif target_zone in RIGHT_ZONES:
 		target_side = "right"
 
-	# Curving TOWARD the target side is correct
-	# Left swerve curves ball to the RIGHT (from kicker's view)
-	# Right swerve curves ball to the LEFT
 	var correct_curve = false
 	if target_side == "right" and curve == CurveDirection.LEFT_SWERVE:
-		correct_curve = true  # Ball curves right
+		correct_curve = true
 	elif target_side == "left" and curve == CurveDirection.RIGHT_SWERVE:
-		correct_curve = true  # Ball curves left
+		correct_curve = true
 	elif target_side == "center":
-		correct_curve = false  # Center targets don't benefit much
+		correct_curve = false
 
 	if correct_curve:
-		return roundi(10.0 * tec_factor)  # Up to +10%
+		return roundi(10.0 * tec_factor)
 	else:
-		return roundi(-15.0 * tec_factor)  # Up to -15%
+		return roundi(-15.0 * tec_factor)
 
 
 func _is_correct_curve(target_zone: String, curve: CurveDirection) -> bool:
@@ -443,6 +337,51 @@ func _is_correct_curve(target_zone: String, curve: CurveDirection) -> bool:
 
 	return false
 
+
+func _update_curve_hint() -> void:
+	if selected_zone.is_empty():
+		curve_hint_label.text = "Select a zone first"
+		return
+
+	var target_side = "center"
+	if selected_zone in LEFT_ZONES:
+		target_side = "left"
+	elif selected_zone in RIGHT_ZONES:
+		target_side = "right"
+
+	match target_side:
+		"left":
+			curve_hint_label.text = "Right swerve curves toward left targets"
+		"right":
+			curve_hint_label.text = "Left swerve curves toward right targets"
+		"center":
+			curve_hint_label.text = "Center targets: curve less effective"
+
+
+func _reset_curve_selection() -> void:
+	for i in range(curve_buttons.size()):
+		var btn = curve_buttons[i]
+		var style = _create_button_style(TrainingConstants.COLOR_DEFAULT, TrainingConstants.BORDER_COLOR)
+		btn.add_theme_stylebox_override("normal", style)
+		btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+	selected_curve = CurveDirection.STRAIGHT
+	_highlight_curve_button(1)
+
+
+func _highlight_curve_button(index: int) -> void:
+	for i in range(curve_buttons.size()):
+		var btn = curve_buttons[i]
+		var style: StyleBoxFlat
+		if i == index:
+			style = _create_button_style(TrainingConstants.COLOR_SELECTED, TrainingConstants.ACCENT_GREEN)
+		else:
+			style = _create_button_style(TrainingConstants.COLOR_DEFAULT, TrainingConstants.BORDER_COLOR)
+		btn.add_theme_stylebox_override("normal", style)
+		btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+
+# ===== STATE MANAGEMENT =====
 
 func _set_state(new_state: DrillState) -> void:
 	current_state = new_state
@@ -498,67 +437,11 @@ func _enable_curve_selection(enabled: bool) -> void:
 		btn.disabled = not enabled
 
 
-func _reset_curve_selection() -> void:
-	for i in range(curve_buttons.size()):
-		var btn = curve_buttons[i]
-		var style = StyleBoxFlat.new()
-		style.bg_color = COLOR_DEFAULT
-		style.border_width_left = 2
-		style.border_width_top = 2
-		style.border_width_right = 2
-		style.border_width_bottom = 2
-		style.border_color = BORDER_COLOR
-		style.set_corner_radius_all(6)
-		btn.add_theme_stylebox_override("normal", style)
-		btn.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	# Default select straight
-	selected_curve = CurveDirection.STRAIGHT
-	_highlight_curve_button(1)
-
-
-func _highlight_curve_button(index: int) -> void:
-	for i in range(curve_buttons.size()):
-		var btn = curve_buttons[i]
-		var style = StyleBoxFlat.new()
-		if i == index:
-			style.bg_color = COLOR_SELECTED  # Green highlight
-			style.border_color = ACCENT_GREEN
-		else:
-			style.bg_color = COLOR_DEFAULT
-			style.border_color = BORDER_COLOR
-		style.border_width_left = 2
-		style.border_width_top = 2
-		style.border_width_right = 2
-		style.border_width_bottom = 2
-		style.set_corner_radius_all(6)
-		btn.add_theme_stylebox_override("normal", style)
-		btn.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-
-func _update_curve_hint() -> void:
-	if selected_zone.is_empty():
-		curve_hint_label.text = "Select a zone first"
-		return
-
-	var target_side = "center"
-	if selected_zone in LEFT_ZONES:
-		target_side = "left"
-	elif selected_zone in RIGHT_ZONES:
-		target_side = "right"
-
-	match target_side:
-		"left":
-			curve_hint_label.text = "Right swerve curves toward left targets"
-		"right":
-			curve_hint_label.text = "Left swerve curves toward right targets"
-		"center":
-			curve_hint_label.text = "Center targets: curve less effective"
-
+# ===== INPUT HANDLING =====
 
 func _input(event: InputEvent) -> void:
 	if current_state == DrillState.SELECTING_CURVE or current_state == DrillState.CHARGING_POWER:
-		if event.is_action_pressed("ui_select"):  # SPACE
+		if event.is_action_pressed("ui_select"):
 			if current_state == DrillState.SELECTING_CURVE:
 				_start_charging()
 		elif event.is_action_released("ui_select"):
@@ -582,38 +465,10 @@ func _on_charge_tick() -> void:
 		charge_timer.stop()
 		return
 
-	current_power = minf(current_power + CHARGE_RATE * charge_timer.wait_time, 100.0)
+	current_power = minf(current_power + TrainingConstants.CHARGE_RATE * charge_timer.wait_time, 100.0)
 	power_bar.value = current_power
-	_update_power_bar_color()
+	_update_power_bar_color(power_bar, current_power)
 	_update_modifiers_display()
-
-
-func _update_power_bar_color() -> void:
-	var color: Color
-	if current_power < 40:
-		color = COLOR_FAIL  # Darker red - weak
-	elif current_power < 70:
-		color = COLOR_WARNING  # Amber - good
-	elif current_power <= 85:
-		color = COLOR_SUCCESS  # Console green - optimal
-	else:
-		color = COLOR_CONTESTED  # Orange - overpowered
-
-	var fill_style = StyleBoxFlat.new()
-	fill_style.bg_color = color
-	fill_style.set_corner_radius_all(4)
-	power_bar.add_theme_stylebox_override("fill", fill_style)
-
-	# Set dark background for power bar
-	var bg_style = StyleBoxFlat.new()
-	bg_style.bg_color = COLOR_DEFAULT
-	bg_style.border_width_left = 1
-	bg_style.border_width_top = 1
-	bg_style.border_width_right = 1
-	bg_style.border_width_bottom = 1
-	bg_style.border_color = BORDER_COLOR
-	bg_style.set_corner_radius_all(4)
-	power_bar.add_theme_stylebox_override("background", bg_style)
 
 
 func _release_shot() -> void:
@@ -623,21 +478,17 @@ func _release_shot() -> void:
 	_resolve_freekick()
 
 
+# ===== EVENT HANDLERS =====
+
 func _on_zone_selected(zone: String) -> void:
 	if current_state != DrillState.SELECTING_ZONE:
 		return
 
-	# Reset zone colors to blocking display
 	_update_zone_blocking_display()
-
-	# Highlight new selection with green
 	selected_zone = zone
-	_set_zone_button_style(zone, COLOR_SELECTED, ACCENT_GREEN)
-
+	_set_zone_button_style(zone, TrainingConstants.COLOR_SELECTED, TrainingConstants.ACCENT_GREEN)
 	_update_modifiers_display()
 	AudioManager.play_ui_click()
-
-	# Move to curve selection
 	_set_state(DrillState.SELECTING_CURVE)
 
 
@@ -647,13 +498,36 @@ func _on_curve_selected(curve: CurveDirection) -> void:
 
 	selected_curve = curve
 	_highlight_curve_button(curve as int)
-
 	shoot_button.disabled = false
 	shoot_button.text = "Hold SPACE to Charge Power"
-
 	_update_modifiers_display()
 	AudioManager.play_ui_click()
 
+
+func _on_shoot_pressed() -> void:
+	if current_state == DrillState.SELECTING_CURVE:
+		_start_charging()
+
+
+func _on_continue_pressed() -> void:
+	if current_state == DrillState.SHOWING_RESULT:
+		selected_zone = ""
+		selected_curve = CurveDirection.STRAIGHT
+		current_power = 0.0
+		power_bar.value = 0
+		_generate_new_wall_position()
+		_update_modifiers_display()
+		skill_check_details.text = "Take a free kick to see the skill check math..."
+		narration_label.text = "[i]The wall sets itself. Pick your target...[/i]"
+		_set_state(DrillState.SELECTING_ZONE)
+		AudioManager.play_ui_click()
+
+
+func _on_exit_pressed() -> void:
+	_handle_exit()
+
+
+# ===== UI HELPERS =====
 
 func _set_zone_button_style(zone: String, bg_color: Color, border_color: Color) -> void:
 	var btn = zone_buttons.get(zone)
@@ -667,7 +541,7 @@ func _set_zone_button_style(zone: String, bg_color: Color, border_color: Color) 
 		style.border_color = border_color
 		style.set_corner_radius_all(6)
 		btn.add_theme_stylebox_override("normal", style)
-		btn.add_theme_color_override("font_color", TEXT_PRIMARY)
+		btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
 
 
 func _update_modifiers_display() -> void:
@@ -685,11 +559,11 @@ func _update_modifiers_display() -> void:
 
 	var tec = player.get_effective_stat("TEC")
 
-	var zone_mod = ZONE_MODIFIERS.get(selected_zone, 0)
+	var zone_mod = TrainingConstants.ZONE_MODIFIERS.get(selected_zone, 0)
 	var wall_mod = _get_wall_modifier(selected_zone)
 	var curve_mod = _get_curve_modifier(selected_zone, selected_curve, tec)
-	var power_mod = _get_power_modifier(current_power)
-	var power_name = _get_power_name(current_power)
+	var power_mod = TrainingConstants.get_power_modifier(current_power)
+	var power_name = TrainingConstants.get_power_name(current_power)
 	var diff = DIFFICULTY_SETTINGS[current_difficulty]
 
 	zone_mod_label.text = "Zone: %+d%%" % zone_mod
@@ -708,19 +582,11 @@ func _update_modifiers_display() -> void:
 	final_chance_label.text = "Final: %.1f%%" % final
 
 
-func _get_power_modifier(power: float) -> int:
-	for range_data in POWER_RANGES:
-		if power >= range_data.min and power <= range_data.max:
-			return range_data.modifier
-	return 0
+func _update_score() -> void:
+	_update_score_display(score_label, attempt_counter, "Attempt")
 
 
-func _get_power_name(power: float) -> String:
-	for range_data in POWER_RANGES:
-		if power >= range_data.min and power <= range_data.max:
-			return range_data.name
-	return "Unknown"
-
+# ===== RESOLUTION =====
 
 func _resolve_freekick() -> void:
 	var player = GameManager.player_data
@@ -731,17 +597,15 @@ func _resolve_freekick() -> void:
 	var tec = player.get_effective_stat("TEC")
 	var diff = DIFFICULTY_SETTINGS[current_difficulty]
 
-	# Calculate success chance
 	var base_chance = _calculate_base_chance(sho, tec)
-	var zone_mod = ZONE_MODIFIERS.get(selected_zone, 0)
+	var zone_mod = TrainingConstants.ZONE_MODIFIERS.get(selected_zone, 0)
 	var wall_mod = _get_wall_modifier(selected_zone)
 	var curve_mod = _get_curve_modifier(selected_zone, selected_curve, tec)
-	var power_mod = _get_power_modifier(current_power)
+	var power_mod = TrainingConstants.get_power_modifier(current_power)
 	var distance_mod = diff.base_mod
 
 	var success_chance = base_chance + zone_mod + wall_mod + curve_mod + power_mod + distance_mod
 
-	# Roll for shot on target
 	var roll = randf() * 100.0
 	var shot_on_target = roll <= success_chance
 
@@ -751,7 +615,7 @@ func _resolve_freekick() -> void:
 	var result: Dictionary = {
 		"zone": selected_zone,
 		"power": current_power,
-		"power_name": _get_power_name(current_power),
+		"power_name": TrainingConstants.get_power_name(current_power),
 		"curve": selected_curve,
 		"curve_name": ["Left Swerve", "Straight", "Right Swerve"][selected_curve as int],
 		"wall_position": current_wall_position,
@@ -772,46 +636,38 @@ func _resolve_freekick() -> void:
 	}
 
 	if shot_on_target:
-		# GK attempts save
 		var gk_result = _resolve_gk_save(selected_zone, diff)
 		result.gk_save_chance = gk_result.save_chance
 		result.gk_roll = gk_result.roll
 		result.scored = not gk_result.saved
 
-	# Track result
 	attempts_taken += 1
 	if result.scored:
-		goals_scored += 1
+		successes += 1
 		if is_top_corner:
 			top_corner_goals += 1
 		if used_correct_curve:
 			curve_goals += 1
 	session_results.append(result)
 
-	# Show result
 	_display_result(result)
-	_update_score_display()
+	_update_score()
 
-	# Check for drill completion
-	if attempts_taken >= FREEKICKS_PER_SESSION:
+	if attempts_taken >= TrainingConstants.ATTEMPTS_PER_SESSION:
 		_complete_drill()
 	else:
 		_set_state(DrillState.SHOWING_RESULT)
 
 
 func _resolve_gk_save(target_zone: String, diff: Dictionary) -> Dictionary:
-	# GK save chance based on difficulty and zone
 	var base_save_chance = diff.gk_stat * 0.4
 
-	# Top corners are harder to save
 	if target_zone in TOP_CORNER_ZONES:
 		base_save_chance -= 15.0
-	# Mid zones are easier
 	elif target_zone in ["MID_LEFT", "MID_CENTER", "MID_RIGHT"]:
 		base_save_chance += 10.0
-	# Low zones blocked by wall are rarely reached
 	elif _get_wall_modifier(target_zone) < 0:
-		base_save_chance -= 5.0  # Ball had to bend around wall
+		base_save_chance -= 5.0
 
 	base_save_chance = clampf(base_save_chance, 5.0, 85.0)
 
@@ -826,13 +682,11 @@ func _resolve_gk_save(target_zone: String, diff: Dictionary) -> Dictionary:
 
 
 func _display_result(result: Dictionary) -> void:
-	# Update zone button color
 	if result.scored:
-		_set_zone_button_style(selected_zone, COLOR_SUCCESS, Color(0, 0.6, 0.3))  # Green - goal
+		_set_zone_button_style(selected_zone, TrainingConstants.COLOR_SUCCESS, Color(0, 0.6, 0.3))
 	else:
-		_set_zone_button_style(selected_zone, COLOR_FAIL, Color(0.6, 0.2, 0.2))  # Red - miss/save
+		_set_zone_button_style(selected_zone, TrainingConstants.COLOR_FAIL, Color(0.6, 0.2, 0.2))
 
-	# Build skill check breakdown
 	var breakdown = ""
 	breakdown += "[b]Free Kick Calculation:[/b]\n"
 	breakdown += "Base: (SHO × 0.6) + (TEC × 0.4) = %.1f%%\n" % result.base_chance
@@ -870,8 +724,6 @@ func _display_result(result: Dictionary) -> void:
 			breakdown += "[color=red]Shot off target! MISSED![/color]"
 
 	skill_check_details.text = breakdown
-
-	# Show narration
 	_show_result_narration(result)
 
 
@@ -898,172 +750,19 @@ func _show_result_narration(result: Dictionary) -> void:
 	narration_label.text = "[i]%s[/i]" % narrative.text
 
 
-func _show_session_start_narration() -> void:
-	var narrative = NarrativeEngine.generate_dialogue("freekick", "session_start", {})
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-
-func _update_score_display() -> void:
-	score_label.text = "%d / %d" % [goals_scored, FREEKICKS_PER_SESSION]
-	attempt_counter.text = "Attempt %d of %d" % [mini(attempts_taken + 1, FREEKICKS_PER_SESSION), FREEKICKS_PER_SESSION]
-
-
 func _complete_drill() -> void:
 	_set_state(DrillState.DRILL_COMPLETE)
-
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * attempts_taken
-	total_xp += XP_PER_GOAL * goals_scored
-	total_xp += XP_TOP_CORNER_BONUS * top_corner_goals
-	total_xp += XP_CURVE_GOAL_BONUS * curve_goals
-
-	if goals_scored >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if goals_scored >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var sho_xp = (STAT_XP_PER_GOAL * goals_scored) + (STAT_XP_PER_MISS * (attempts_taken - goals_scored))
-	var tec_xp = TEC_XP_PER_ATTEMPT * attempts_taken
-
-	# Build summary
-	var summary = "[b]Drill Complete![/b]\n\n"
-	summary += "Goals: %d / %d (%.0f%%)\n\n" % [goals_scored, attempts_taken, (float(goals_scored) / attempts_taken) * 100]
-	summary += "[b]XP Earned:[/b]\n"
-	summary += "Base: %d XP (%d attempts × %d)\n" % [XP_PER_ATTEMPT * attempts_taken, attempts_taken, XP_PER_ATTEMPT]
-	summary += "Goals: +%d XP (%d goals × %d)\n" % [XP_PER_GOAL * goals_scored, goals_scored, XP_PER_GOAL]
-
-	if top_corner_goals > 0:
-		summary += "Top Corners: +%d XP (%d × %d)\n" % [XP_TOP_CORNER_BONUS * top_corner_goals, top_corner_goals, XP_TOP_CORNER_BONUS]
-	if curve_goals > 0:
-		summary += "Curve Goals: +%d XP (%d × %d)\n" % [XP_CURVE_GOAL_BONUS * curve_goals, curve_goals, XP_CURVE_GOAL_BONUS]
-
-	if goals_scored >= 10:
-		summary += "Perfect Session: +%d XP\n" % XP_PERFECT_SESSION_BONUS
-	elif goals_scored >= 7:
-		summary += "Good Session: +%d XP\n" % XP_GOOD_SESSION_BONUS
-
-	summary += "[b]Total: %d XP[/b]\n\n" % total_xp
-	summary += "[b]Stat XP:[/b]\n"
-	summary += "SHO: +%d\n" % sho_xp
-	summary += "TEC: +%d\n" % tec_xp
-
-	skill_check_details.text = summary
-
-	# Show session end narration
-	var context = {"goals": str(goals_scored), "total": str(attempts_taken)}
-	var narrative = NarrativeEngine.generate_dialogue("freekick", "session_end", context)
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-	# Store results for when drill is exited
-	var results = {
+	skill_check_details.text = _build_xp_summary()
+	_show_session_end_narration(narration_label)
+	_save_best_score()
+	drill_completed.emit({
 		"attempts_taken": attempts_taken,
-		"goals_scored": goals_scored,
+		"goals_scored": successes,
 		"top_corner_goals": top_corner_goals,
 		"curve_goals": curve_goals,
-		"accuracy": float(goals_scored) / attempts_taken,
-		"total_xp": total_xp,
-		"sho_xp": sho_xp,
-		"tec_xp": tec_xp,
+		"accuracy": float(successes) / attempts_taken,
+		"total_xp": _calculate_total_xp(),
+		"sho_xp": _calculate_primary_stat_xp(),
+		"tec_xp": _calculate_secondary_stat_xp(),
 		"session_results": session_results
-	}
-
-	# Save best score for simulation feature
-	_save_best_score()
-
-	drill_completed.emit(results)
-
-
-func _save_best_score() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	var current_record = player.training_records.get("freekick_drill", {})
-	var previous_best = current_record.get("best_score", 0)
-
-	if goals_scored > previous_best:
-		player.training_records["freekick_drill"] = {
-			"best_score": goals_scored,
-			"attempts": FREEKICKS_PER_SESSION,
-			"best_accuracy": float(goals_scored) / FREEKICKS_PER_SESSION
-		}
-
-
-func _on_difficulty_changed(index: int) -> void:
-	var keys = DIFFICULTY_SETTINGS.keys()
-	if index < keys.size():
-		current_difficulty = keys[index]
-		_update_wall_display()
-	AudioManager.play_ui_click()
-
-
-func _on_shoot_pressed() -> void:
-	if current_state == DrillState.SELECTING_CURVE:
-		_start_charging()
-
-
-func _on_continue_pressed() -> void:
-	if current_state == DrillState.SHOWING_RESULT:
-		# Reset for next attempt
-		selected_zone = ""
-		selected_curve = CurveDirection.STRAIGHT
-		current_power = 0.0
-		power_bar.value = 0
-
-		# Generate new wall position
-		_generate_new_wall_position()
-
-		_update_modifiers_display()
-		skill_check_details.text = "Take a free kick to see the skill check math..."
-		narration_label.text = "[i]The wall sets itself. Pick your target...[/i]"
-
-		_set_state(DrillState.SELECTING_ZONE)
-		AudioManager.play_ui_click()
-
-
-func _on_exit_pressed() -> void:
-	AudioManager.play_ui_click()
-
-	# Apply rewards if drill was completed
-	if current_state == DrillState.DRILL_COMPLETE:
-		_apply_rewards()
-
-	# Return to console dashboard
-	get_tree().change_scene_to_file("res://scenes/dashboard/console_dashboard.tscn")
-
-
-func _apply_rewards() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * attempts_taken
-	total_xp += XP_PER_GOAL * goals_scored
-	total_xp += XP_TOP_CORNER_BONUS * top_corner_goals
-	total_xp += XP_CURVE_GOAL_BONUS * curve_goals
-
-	if goals_scored >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if goals_scored >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var sho_xp = (STAT_XP_PER_GOAL * goals_scored) + (STAT_XP_PER_MISS * (attempts_taken - goals_scored))
-	var tec_xp = TEC_XP_PER_ATTEMPT * attempts_taken
-
-	# Apply to player
-	player.stamina_current = maxi(player.stamina_current - STAMINA_COST, 0)
-	player.add_xp(total_xp)
-	player.add_stat_xp("SHO", sho_xp)
-	player.add_stat_xp("TEC", tec_xp)
-
-	# Advance time
-	DesktopManager.advance_time(1)
-
-	# Show notification
-	DesktopManager.show_notification(
-		"Free Kick Practice Complete",
-		"Scored %d/%d! Earned %d XP" % [goals_scored, attempts_taken, total_xp],
-		"",
-		"training"
-	)
+	})

--- a/scripts/training/penalty_drill.gd
+++ b/scripts/training/penalty_drill.gd
@@ -1,20 +1,19 @@
-extends Control
+extends TrainingDrillBase
 ## PenaltyDrill - Penalty kick training mini-game
 ## Features 3x3 goal targeting, power charging, skill checks, and adaptive GK
 
-signal drill_completed(results: Dictionary)
 
 # Static function for simulating rewards without playing
 static func calculate_simulated_rewards(goals: int, attempts: int = 10) -> Dictionary:
-	var total_xp = XP_PER_ATTEMPT * attempts
+	var total_xp = TrainingConstants.XP_PER_ATTEMPT * attempts
 	total_xp += XP_PER_GOAL * goals
 
 	if goals >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
+		total_xp += TrainingConstants.XP_GOOD_SESSION_BONUS
 	if goals >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
+		total_xp += TrainingConstants.XP_PERFECT_SESSION_BONUS
 
-	var sho_xp = (STAT_XP_PER_GOAL * goals) + (STAT_XP_PER_MISS * (attempts - goals))
+	var sho_xp = (TrainingConstants.STAT_XP_PER_SUCCESS * goals) + (TrainingConstants.STAT_XP_PER_FAIL * (attempts - goals))
 	var men_xp = MEN_XP_PER_ATTEMPT * attempts
 
 	return {
@@ -23,7 +22,7 @@ static func calculate_simulated_rewards(goals: int, attempts: int = 10) -> Dicti
 		"total_xp": total_xp,
 		"sho_xp": sho_xp,
 		"men_xp": men_xp,
-		"stamina_cost": STAMINA_COST
+		"stamina_cost": TrainingConstants.STAMINA_COST
 	}
 
 
@@ -43,13 +42,6 @@ const DIFFICULTY_SETTINGS: Dictionary = {
 	"elite": {"name": "Elite GK", "gk_stat": 75, "learning_rate": 0.5, "unlocked": false}
 }
 
-# Zone modifiers
-const ZONE_MODIFIERS: Dictionary = {
-	"TOP_LEFT": -20, "TOP_CENTER": -15, "TOP_RIGHT": -20,
-	"MID_LEFT": -10, "MID_CENTER": 5, "MID_RIGHT": -10,
-	"LOW_LEFT": -10, "LOW_CENTER": -5, "LOW_RIGHT": -10
-}
-
 # Zone adjacency for GK saves
 const ZONE_ADJACENCY: Dictionary = {
 	"TOP_LEFT": ["TOP_CENTER", "MID_LEFT"],
@@ -63,44 +55,9 @@ const ZONE_ADJACENCY: Dictionary = {
 	"LOW_RIGHT": ["MID_RIGHT", "LOW_CENTER"]
 }
 
-# Power modifiers
-const POWER_RANGES: Array[Dictionary] = [
-	{"min": 0, "max": 39, "name": "Weak", "modifier": -15},
-	{"min": 40, "max": 69, "name": "Good", "modifier": 0},
-	{"min": 70, "max": 85, "name": "Optimal", "modifier": 5},
-	{"min": 86, "max": 100, "name": "Overpowered", "modifier": -10}
-]
-
-# XP rewards
-const XP_PER_ATTEMPT: int = 5
+# Drill-specific XP rewards
 const XP_PER_GOAL: int = 10
-const XP_GOOD_SESSION_BONUS: int = 25  # 7+ goals
-const XP_PERFECT_SESSION_BONUS: int = 50  # 10/10
-const STAT_XP_PER_GOAL: int = 3
-const STAT_XP_PER_MISS: int = 1
 const MEN_XP_PER_ATTEMPT: int = 2
-const STAMINA_COST: int = 15
-const PENALTIES_PER_SESSION: int = 10
-const CHARGE_RATE: float = 66.67  # 100% in 1.5 seconds
-
-# Console Dashboard Colors
-const BG_DARK = Color(0.039, 0.086, 0.157)
-const PANEL_BG = Color(0.06, 0.1, 0.18, 0.95)
-const BORDER_COLOR = Color(0.15, 0.25, 0.4)
-const ACCENT_GREEN = Color(0, 1, 0.5)
-const TEXT_PRIMARY = Color(0.9, 0.95, 1)
-const TEXT_SECONDARY = Color(0.6, 0.65, 0.7)
-const TEXT_MUTED = Color(0.5, 0.55, 0.6)
-
-# State Colors
-const COLOR_DEFAULT = Color(0.1, 0.15, 0.25)
-const COLOR_SELECTED = Color(0, 0.6, 0.3)
-const COLOR_SUCCESS = Color(0, 0.8, 0.4)
-const COLOR_FAIL = Color(0.8, 0.3, 0.3)
-const COLOR_WARNING = Color(0.9, 0.7, 0.2)
-const COLOR_BLOCKED = Color(0.6, 0.2, 0.2)
-const COLOR_CONTESTED = Color(0.8, 0.5, 0.2)
-const COLOR_OPEN = Color(0.2, 0.5, 0.8)
 
 # Node references
 @onready var difficulty_selector: OptionButton = $VBoxContainer/HeaderSection/DifficultyContainer/DifficultySelector
@@ -125,15 +82,9 @@ const COLOR_OPEN = Color(0.2, 0.5, 0.8)
 
 # State
 var current_state: DrillState = DrillState.SETUP
-var current_difficulty: String = "youth"
 var selected_zone: String = ""
 var current_power: float = 0.0
 var is_charging: bool = false
-
-# Session tracking
-var penalties_taken: int = 0
-var goals_scored: int = 0
-var session_results: Array[Dictionary] = []
 
 # GK pattern learning
 var player_zone_history: Array[String] = []
@@ -143,45 +94,63 @@ var gk_zone_weights: Dictionary = {}
 var zone_buttons: Dictionary = {}
 
 
+# ===== OVERRIDES =====
+
+func _get_drill_name() -> String:
+	return "penalty"
+
+
+func _get_primary_stat() -> String:
+	return "SHO"
+
+
+func _get_secondary_stat() -> String:
+	return "MEN"
+
+
+func _get_difficulty_settings() -> Dictionary:
+	return DIFFICULTY_SETTINGS
+
+
+func _get_xp_per_success() -> int:
+	return XP_PER_GOAL
+
+
+func _get_success_label() -> String:
+	return "Goals"
+
+
+func _is_drill_complete() -> bool:
+	return current_state == DrillState.DRILL_COMPLETE
+
+
+func _get_completion_title() -> String:
+	return "Penalty Practice Complete"
+
+
+func _calculate_secondary_stat_xp(_xp_per_attempt: int = 2) -> int:
+	return MEN_XP_PER_ATTEMPT * attempts_taken
+
+
+# ===== SETUP =====
+
 func _ready() -> void:
-	_setup_difficulty_selector()
+	_setup_difficulty_selector(difficulty_selector)
 	_setup_zone_buttons()
 	_setup_signals()
-	_style_footer_buttons()
+	_style_footer_buttons(continue_button, exit_button)
+	_style_shoot_button(shoot_button)
 	_init_gk_weights()
 	_update_player_stats_display()
 	_set_state(DrillState.SELECTING_ZONE)
-	_show_session_start_narration()
-
-
-func _setup_difficulty_selector() -> void:
-	difficulty_selector.clear()
-	var idx = 0
-	for diff_id in DIFFICULTY_SETTINGS:
-		var diff = DIFFICULTY_SETTINGS[diff_id]
-		var text = diff.name
-		if not diff.unlocked:
-			text += " (Locked)"
-		difficulty_selector.add_item(text, idx)
-		if not diff.unlocked:
-			difficulty_selector.set_item_disabled(idx, true)
-		idx += 1
-	difficulty_selector.selected = 0
-	difficulty_selector.item_selected.connect(_on_difficulty_changed)
+	_show_session_start_narration(narration_label)
 
 
 func _setup_zone_buttons() -> void:
-	var zone_names = ["TOP_LEFT", "TOP_CENTER", "TOP_RIGHT",
-					  "MID_LEFT", "MID_CENTER", "MID_RIGHT",
-					  "LOW_LEFT", "LOW_CENTER", "LOW_RIGHT"]
-	var button_names = ["TopLeft", "TopCenter", "TopRight",
-						"MidLeft", "MidCenter", "MidRight",
-						"LowLeft", "LowCenter", "LowRight"]
-
-	for i in range(zone_names.size()):
-		var btn = zone_grid.get_node(button_names[i])
-		zone_buttons[zone_names[i]] = btn
-		btn.pressed.connect(_on_zone_selected.bind(zone_names[i]))
+	for i in range(TrainingConstants.ZONE_NAMES.size()):
+		var btn = zone_grid.get_node(TrainingConstants.ZONE_BUTTON_NAMES[i])
+		zone_buttons[TrainingConstants.ZONE_NAMES[i]] = btn
+		btn.pressed.connect(_on_zone_selected.bind(TrainingConstants.ZONE_NAMES[i]))
 
 
 func _setup_signals() -> void:
@@ -191,76 +160,8 @@ func _setup_signals() -> void:
 	charge_timer.timeout.connect(_on_charge_tick)
 
 
-func _style_footer_buttons() -> void:
-	# Style Continue button with console green accent
-	var continue_style = StyleBoxFlat.new()
-	continue_style.bg_color = Color(0, 0.6, 0.3)
-	continue_style.border_width_left = 2
-	continue_style.border_width_top = 2
-	continue_style.border_width_right = 2
-	continue_style.border_width_bottom = 2
-	continue_style.border_color = Color(0, 0.8, 0.4)
-	continue_style.set_corner_radius_all(6)
-	continue_button.add_theme_stylebox_override("normal", continue_style)
-	continue_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var continue_hover = continue_style.duplicate()
-	continue_hover.bg_color = Color(0, 0.7, 0.35)
-	continue_button.add_theme_stylebox_override("hover", continue_hover)
-
-	var continue_pressed = continue_style.duplicate()
-	continue_pressed.bg_color = Color(0, 0.5, 0.25)
-	continue_button.add_theme_stylebox_override("pressed", continue_pressed)
-
-	# Style Exit button with dark panel style
-	var exit_style = StyleBoxFlat.new()
-	exit_style.bg_color = COLOR_DEFAULT
-	exit_style.border_width_left = 2
-	exit_style.border_width_top = 2
-	exit_style.border_width_right = 2
-	exit_style.border_width_bottom = 2
-	exit_style.border_color = BORDER_COLOR
-	exit_style.set_corner_radius_all(6)
-	exit_button.add_theme_stylebox_override("normal", exit_style)
-	exit_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var exit_hover = exit_style.duplicate()
-	exit_hover.bg_color = Color(0.15, 0.2, 0.3)
-	exit_button.add_theme_stylebox_override("hover", exit_hover)
-
-	var exit_pressed = exit_style.duplicate()
-	exit_pressed.bg_color = Color(0.08, 0.12, 0.2)
-	exit_button.add_theme_stylebox_override("pressed", exit_pressed)
-
-	# Style Shoot button with console theme
-	var shoot_style = StyleBoxFlat.new()
-	shoot_style.bg_color = COLOR_DEFAULT
-	shoot_style.border_width_left = 2
-	shoot_style.border_width_top = 2
-	shoot_style.border_width_right = 2
-	shoot_style.border_width_bottom = 2
-	shoot_style.border_color = ACCENT_GREEN
-	shoot_style.set_corner_radius_all(6)
-	shoot_button.add_theme_stylebox_override("normal", shoot_style)
-	shoot_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var shoot_hover = shoot_style.duplicate()
-	shoot_hover.bg_color = Color(0.15, 0.2, 0.3)
-	shoot_button.add_theme_stylebox_override("hover", shoot_hover)
-
-	var shoot_pressed = shoot_style.duplicate()
-	shoot_pressed.bg_color = Color(0, 0.5, 0.25)
-	shoot_button.add_theme_stylebox_override("pressed", shoot_pressed)
-
-	var shoot_disabled = shoot_style.duplicate()
-	shoot_disabled.bg_color = Color(0.08, 0.1, 0.15)
-	shoot_disabled.border_color = Color(0.2, 0.25, 0.35)
-	shoot_button.add_theme_stylebox_override("disabled", shoot_disabled)
-	shoot_button.add_theme_color_override("font_disabled_color", TEXT_MUTED)
-
-
 func _init_gk_weights() -> void:
-	for zone in ZONE_MODIFIERS:
+	for zone in TrainingConstants.ZONE_MODIFIERS:
 		gk_zone_weights[zone] = 1.0
 
 
@@ -281,6 +182,8 @@ func _update_player_stats_display() -> void:
 func _calculate_base_chance(sho: int, men: int) -> float:
 	return (sho * 0.7) + (men * 0.3)
 
+
+# ===== STATE MANAGEMENT =====
 
 func _set_state(new_state: DrillState) -> void:
 	current_state = new_state
@@ -318,9 +221,11 @@ func _enable_zone_selection(enabled: bool) -> void:
 		zone_buttons[zone].disabled = not enabled
 
 
+# ===== INPUT HANDLING =====
+
 func _input(event: InputEvent) -> void:
 	if current_state == DrillState.SELECTING_ZONE or current_state == DrillState.CHARGING_POWER:
-		if event.is_action_pressed("ui_select"):  # SPACE
+		if event.is_action_pressed("ui_select"):
 			if selected_zone.is_empty():
 				return
 			_start_charging()
@@ -345,39 +250,10 @@ func _on_charge_tick() -> void:
 		charge_timer.stop()
 		return
 
-	current_power = minf(current_power + CHARGE_RATE * charge_timer.wait_time, 100.0)
+	current_power = minf(current_power + TrainingConstants.CHARGE_RATE * charge_timer.wait_time, 100.0)
 	power_bar.value = current_power
-	_update_power_bar_color()
+	_update_power_bar_color(power_bar, current_power)
 	_update_modifiers_display()
-
-
-func _update_power_bar_color() -> void:
-	var color: Color
-	if current_power < 40:
-		color = COLOR_FAIL  # Darker red - weak
-	elif current_power < 70:
-		color = COLOR_WARNING  # Amber - good
-	elif current_power <= 85:
-		color = COLOR_SUCCESS  # Console green - optimal
-	else:
-		color = COLOR_CONTESTED  # Orange - overpowered
-
-	# Apply color via stylebox override
-	var fill_style = StyleBoxFlat.new()
-	fill_style.bg_color = color
-	fill_style.set_corner_radius_all(4)
-	power_bar.add_theme_stylebox_override("fill", fill_style)
-
-	# Set dark background for power bar
-	var bg_style = StyleBoxFlat.new()
-	bg_style.bg_color = COLOR_DEFAULT
-	bg_style.border_width_left = 1
-	bg_style.border_width_top = 1
-	bg_style.border_width_right = 1
-	bg_style.border_width_bottom = 1
-	bg_style.border_color = BORDER_COLOR
-	bg_style.set_corner_radius_all(4)
-	power_bar.add_theme_stylebox_override("background", bg_style)
 
 
 func _release_shot() -> void:
@@ -387,17 +263,19 @@ func _release_shot() -> void:
 	_resolve_penalty()
 
 
+# ===== EVENT HANDLERS =====
+
 func _on_zone_selected(zone: String) -> void:
 	if current_state != DrillState.SELECTING_ZONE:
 		return
 
-	# Clear previous selection - reset all to default dark
+	# Clear previous selection
 	for z in zone_buttons:
-		_set_zone_button_color(z, COLOR_DEFAULT, BORDER_COLOR)
+		_set_zone_button_color(z, TrainingConstants.COLOR_DEFAULT, TrainingConstants.BORDER_COLOR)
 
-	# Highlight new selection with green
+	# Highlight new selection
 	selected_zone = zone
-	_set_zone_button_color(zone, COLOR_SELECTED, ACCENT_GREEN)
+	_set_zone_button_color(zone, TrainingConstants.COLOR_SELECTED, TrainingConstants.ACCENT_GREEN)
 
 	shoot_button.disabled = false
 	shoot_button.text = "Hold SPACE to Charge Power"
@@ -406,20 +284,39 @@ func _on_zone_selected(zone: String) -> void:
 	AudioManager.play_ui_click()
 
 
-func _set_zone_button_color(zone: String, bg_color: Color, border_color: Color = BORDER_COLOR) -> void:
+func _set_zone_button_color(zone: String, bg_color: Color, border_color: Color = TrainingConstants.BORDER_COLOR) -> void:
 	var btn = zone_buttons.get(zone)
 	if btn:
-		var style = StyleBoxFlat.new()
-		style.bg_color = bg_color
-		style.border_width_left = 2
-		style.border_width_top = 2
-		style.border_width_right = 2
-		style.border_width_bottom = 2
-		style.border_color = border_color
-		style.set_corner_radius_all(6)
-		btn.add_theme_stylebox_override("normal", style)
-		btn.add_theme_color_override("font_color", TEXT_PRIMARY)
+		_set_button_style(btn, bg_color, border_color)
 
+
+func _on_shoot_pressed() -> void:
+	if current_state == DrillState.SELECTING_ZONE and not selected_zone.is_empty():
+		_start_charging()
+
+
+func _on_continue_pressed() -> void:
+	if current_state == DrillState.SHOWING_RESULT:
+		selected_zone = ""
+		current_power = 0.0
+		power_bar.value = 0
+
+		for zone in zone_buttons:
+			_set_zone_button_color(zone, TrainingConstants.COLOR_DEFAULT, TrainingConstants.BORDER_COLOR)
+
+		_update_modifiers_display()
+		skill_check_details.text = "Take a shot to see the skill check math..."
+		narration_label.text = "[i]Step up to the spot again. The goalkeeper sets himself...[/i]"
+
+		_set_state(DrillState.SELECTING_ZONE)
+		AudioManager.play_ui_click()
+
+
+func _on_exit_pressed() -> void:
+	_handle_exit()
+
+
+# ===== UI HELPERS =====
 
 func _update_modifiers_display() -> void:
 	if selected_zone.is_empty():
@@ -429,9 +326,9 @@ func _update_modifiers_display() -> void:
 		final_chance_label.text = "Final: --%"
 		return
 
-	var zone_mod = ZONE_MODIFIERS.get(selected_zone, 0)
-	var power_mod = _get_power_modifier(current_power)
-	var power_name = _get_power_name(current_power)
+	var zone_mod = TrainingConstants.ZONE_MODIFIERS.get(selected_zone, 0)
+	var power_mod = TrainingConstants.get_power_modifier(current_power)
+	var power_name = TrainingConstants.get_power_name(current_power)
 
 	zone_mod_label.text = "Zone: %+d%%" % zone_mod
 	power_mod_label.text = "Power: %s (%+d%%)" % [power_name, power_mod]
@@ -444,19 +341,11 @@ func _update_modifiers_display() -> void:
 		final_chance_label.text = "Final: %.1f%%" % final
 
 
-func _get_power_modifier(power: float) -> int:
-	for range_data in POWER_RANGES:
-		if power >= range_data.min and power <= range_data.max:
-			return range_data.modifier
-	return 0
+func _update_score() -> void:
+	_update_score_display(score_label, penalty_counter, "Penalty")
 
 
-func _get_power_name(power: float) -> String:
-	for range_data in POWER_RANGES:
-		if power >= range_data.min and power <= range_data.max:
-			return range_data.name
-	return "Unknown"
-
+# ===== RESOLUTION =====
 
 func _resolve_penalty() -> void:
 	var player = GameManager.player_data
@@ -467,20 +356,18 @@ func _resolve_penalty() -> void:
 	var men = player.get_effective_stat("MEN")
 	var diff = DIFFICULTY_SETTINGS[current_difficulty]
 
-	# Calculate success chance
 	var base_chance = _calculate_base_chance(sho, men)
-	var zone_mod = ZONE_MODIFIERS.get(selected_zone, 0)
-	var power_mod = _get_power_modifier(current_power)
+	var zone_mod = TrainingConstants.ZONE_MODIFIERS.get(selected_zone, 0)
+	var power_mod = TrainingConstants.get_power_modifier(current_power)
 	var success_chance = base_chance + zone_mod + power_mod
 
-	# Roll for shot on target
 	var roll = randf() * 100.0
 	var shot_on_target = roll <= success_chance
 
 	var result: Dictionary = {
 		"zone": selected_zone,
 		"power": current_power,
-		"power_name": _get_power_name(current_power),
+		"power_name": TrainingConstants.get_power_name(current_power),
 		"base_chance": base_chance,
 		"zone_mod": zone_mod,
 		"power_mod": power_mod,
@@ -494,7 +381,6 @@ func _resolve_penalty() -> void:
 	}
 
 	if shot_on_target:
-		# GK attempts save
 		var gk_result = _resolve_gk_save(selected_zone, diff)
 		result.gk_dived = gk_result.dive_zone
 		result.gk_save_chance = gk_result.save_chance
@@ -505,38 +391,29 @@ func _resolve_penalty() -> void:
 	player_zone_history.append(selected_zone)
 	_update_gk_weights(diff.learning_rate)
 
-	# Track result
-	penalties_taken += 1
+	attempts_taken += 1
 	if result.scored:
-		goals_scored += 1
+		successes += 1
 	session_results.append(result)
 
-	# Show result
 	_display_result(result)
-	_update_score_display()
+	_update_score()
 
-	# Check for drill completion
-	if penalties_taken >= PENALTIES_PER_SESSION:
+	if attempts_taken >= TrainingConstants.ATTEMPTS_PER_SESSION:
 		_complete_drill()
 	else:
 		_set_state(DrillState.SHOWING_RESULT)
 
 
 func _resolve_gk_save(target_zone: String, diff: Dictionary) -> Dictionary:
-	# Select GK dive zone based on learned weights
 	var dive_zone = _select_gk_dive_zone()
-
-	# Calculate save chance based on dive accuracy
-	var base_save_chance = diff.gk_stat * 0.5  # Base from GK stat
+	var base_save_chance = diff.gk_stat * 0.5
 
 	if dive_zone == target_zone:
-		# Correct guess - high save chance
 		base_save_chance += 40.0
 	elif dive_zone in ZONE_ADJACENCY.get(target_zone, []):
-		# Adjacent zone - moderate save chance
 		base_save_chance += 15.0
 	else:
-		# Wrong side - low save chance
 		base_save_chance -= 20.0
 
 	base_save_chance = clampf(base_save_chance, 5.0, 95.0)
@@ -553,7 +430,6 @@ func _resolve_gk_save(target_zone: String, diff: Dictionary) -> Dictionary:
 
 
 func _select_gk_dive_zone() -> String:
-	# Weighted random selection based on player patterns
 	var total_weight = 0.0
 	for zone in gk_zone_weights:
 		total_weight += gk_zone_weights[zone]
@@ -566,16 +442,15 @@ func _select_gk_dive_zone() -> String:
 		if roll <= cumulative:
 			return zone
 
-	return "MID_CENTER"  # Fallback
+	return "MID_CENTER"
 
 
 func _update_gk_weights(learning_rate: float) -> void:
 	if player_zone_history.is_empty():
 		return
 
-	# Count zone frequencies
 	var zone_counts: Dictionary = {}
-	for zone in ZONE_MODIFIERS:
+	for zone in TrainingConstants.ZONE_MODIFIERS:
 		zone_counts[zone] = 0
 
 	for zone in player_zone_history:
@@ -583,21 +458,18 @@ func _update_gk_weights(learning_rate: float) -> void:
 
 	var total = player_zone_history.size()
 
-	# Update weights based on frequency
 	for zone in gk_zone_weights:
 		var frequency = float(zone_counts[zone]) / total
-		var target_weight = 1.0 + (frequency * 3.0)  # More frequent = higher weight
+		var target_weight = 1.0 + (frequency * 3.0)
 		gk_zone_weights[zone] = lerpf(gk_zone_weights[zone], target_weight, learning_rate)
 
 
 func _display_result(result: Dictionary) -> void:
-	# Update zone button colors
 	if result.scored:
-		_set_zone_button_color(selected_zone, COLOR_SUCCESS, Color(0, 0.6, 0.3))  # Green - goal
+		_set_zone_button_color(selected_zone, TrainingConstants.COLOR_SUCCESS, Color(0, 0.6, 0.3))
 	else:
-		_set_zone_button_color(selected_zone, COLOR_FAIL, Color(0.6, 0.2, 0.2))  # Red - miss/save
+		_set_zone_button_color(selected_zone, TrainingConstants.COLOR_FAIL, Color(0.6, 0.2, 0.2))
 
-	# Build skill check breakdown
 	var breakdown = ""
 	breakdown += "[b]Shot Calculation:[/b]\n"
 	breakdown += "Base: (SHO × 0.7) + (MEN × 0.3) = %.1f%%\n" % result.base_chance
@@ -623,8 +495,6 @@ func _display_result(result: Dictionary) -> void:
 		breakdown += "[color=red]Shot off target! MISSED![/color]"
 
 	skill_check_details.text = breakdown
-
-	# Show narration
 	_show_result_narration(result)
 
 
@@ -645,160 +515,17 @@ func _show_result_narration(result: Dictionary) -> void:
 	narration_label.text = "[i]%s[/i]" % narrative.text
 
 
-func _show_session_start_narration() -> void:
-	var narrative = NarrativeEngine.generate_dialogue("penalty", "session_start", {})
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-
-func _update_score_display() -> void:
-	score_label.text = "%d / %d" % [goals_scored, PENALTIES_PER_SESSION]
-	penalty_counter.text = "Penalty %d of %d" % [mini(penalties_taken + 1, PENALTIES_PER_SESSION), PENALTIES_PER_SESSION]
-
-
 func _complete_drill() -> void:
 	_set_state(DrillState.DRILL_COMPLETE)
-
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * penalties_taken
-	total_xp += XP_PER_GOAL * goals_scored
-
-	if goals_scored >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if goals_scored >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var sho_xp = (STAT_XP_PER_GOAL * goals_scored) + (STAT_XP_PER_MISS * (penalties_taken - goals_scored))
-	var men_xp = MEN_XP_PER_ATTEMPT * penalties_taken
-
-	# Build summary
-	var summary = "[b]Drill Complete![/b]\n\n"
-	summary += "Goals: %d / %d (%.0f%%)\n\n" % [goals_scored, penalties_taken, (float(goals_scored) / penalties_taken) * 100]
-	summary += "[b]XP Earned:[/b]\n"
-	summary += "Base: %d XP (%d attempts × %d)\n" % [XP_PER_ATTEMPT * penalties_taken, penalties_taken, XP_PER_ATTEMPT]
-	summary += "Goals: +%d XP (%d goals × %d)\n" % [XP_PER_GOAL * goals_scored, goals_scored, XP_PER_GOAL]
-
-	if goals_scored >= 10:
-		summary += "Perfect Session: +%d XP\n" % XP_PERFECT_SESSION_BONUS
-	elif goals_scored >= 7:
-		summary += "Good Session: +%d XP\n" % XP_GOOD_SESSION_BONUS
-
-	summary += "[b]Total: %d XP[/b]\n\n" % total_xp
-	summary += "[b]Stat XP:[/b]\n"
-	summary += "SHO: +%d\n" % sho_xp
-	summary += "MEN: +%d\n" % men_xp
-
-	skill_check_details.text = summary
-
-	# Show session end narration
-	var context = {"goals": str(goals_scored), "total": str(penalties_taken)}
-	var narrative = NarrativeEngine.generate_dialogue("penalty", "session_end", context)
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-	# Store results for when drill is exited
-	var results = {
-		"penalties_taken": penalties_taken,
-		"goals_scored": goals_scored,
-		"accuracy": float(goals_scored) / penalties_taken,
-		"total_xp": total_xp,
-		"sho_xp": sho_xp,
-		"men_xp": men_xp,
-		"session_results": session_results
-	}
-
-	# Save best score for simulation feature
+	skill_check_details.text = _build_xp_summary()
+	_show_session_end_narration(narration_label)
 	_save_best_score()
-
-	drill_completed.emit(results)
-
-
-func _save_best_score() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	var current_record = player.training_records.get("penalty_drill", {})
-	var previous_best = current_record.get("best_score", 0)
-
-	if goals_scored > previous_best:
-		player.training_records["penalty_drill"] = {
-			"best_score": goals_scored,
-			"attempts": PENALTIES_PER_SESSION,
-			"best_accuracy": float(goals_scored) / PENALTIES_PER_SESSION
-		}
-
-
-func _on_difficulty_changed(index: int) -> void:
-	var keys = DIFFICULTY_SETTINGS.keys()
-	if index < keys.size():
-		current_difficulty = keys[index]
-	AudioManager.play_ui_click()
-
-
-func _on_shoot_pressed() -> void:
-	if current_state == DrillState.SELECTING_ZONE and not selected_zone.is_empty():
-		_start_charging()
-
-
-func _on_continue_pressed() -> void:
-	if current_state == DrillState.SHOWING_RESULT:
-		# Reset for next penalty
-		selected_zone = ""
-		current_power = 0.0
-		power_bar.value = 0
-
-		# Reset zone button colors to dark theme
-		for zone in zone_buttons:
-			_set_zone_button_color(zone, COLOR_DEFAULT, BORDER_COLOR)
-
-		_update_modifiers_display()
-		skill_check_details.text = "Take a shot to see the skill check math..."
-		narration_label.text = "[i]Step up to the spot again. The goalkeeper sets himself...[/i]"
-
-		_set_state(DrillState.SELECTING_ZONE)
-		AudioManager.play_ui_click()
-
-
-func _on_exit_pressed() -> void:
-	AudioManager.play_ui_click()
-
-	# Apply rewards if drill was completed
-	if current_state == DrillState.DRILL_COMPLETE:
-		_apply_rewards()
-
-	# Return to console dashboard
-	get_tree().change_scene_to_file("res://scenes/dashboard/console_dashboard.tscn")
-
-
-func _apply_rewards() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * penalties_taken
-	total_xp += XP_PER_GOAL * goals_scored
-
-	if goals_scored >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if goals_scored >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var sho_xp = (STAT_XP_PER_GOAL * goals_scored) + (STAT_XP_PER_MISS * (penalties_taken - goals_scored))
-	var men_xp = MEN_XP_PER_ATTEMPT * penalties_taken
-
-	# Apply to player
-	player.stamina_current = maxi(player.stamina_current - STAMINA_COST, 0)
-	player.add_xp(total_xp)
-	player.add_stat_xp("SHO", sho_xp)
-	player.add_stat_xp("MEN", men_xp)
-
-	# Advance time
-	DesktopManager.advance_time(1)
-
-	# Show notification
-	DesktopManager.show_notification(
-		"Penalty Practice Complete",
-		"Scored %d/%d! Earned %d XP" % [goals_scored, penalties_taken, total_xp],
-		"",
-		"training"
-	)
+	drill_completed.emit({
+		"penalties_taken": attempts_taken,
+		"goals_scored": successes,
+		"accuracy": float(successes) / attempts_taken,
+		"total_xp": _calculate_total_xp(),
+		"sho_xp": _calculate_primary_stat_xp(),
+		"men_xp": _calculate_secondary_stat_xp(),
+		"session_results": session_results
+	})

--- a/scripts/training/rondo_drill.gd
+++ b/scripts/training/rondo_drill.gd
@@ -1,33 +1,32 @@
-extends Control
+extends TrainingDrillBase
 ## RondoDrill - Rondo (keep-ball) passing training mini-game
 ## Features pentagon teammate layout, defender AI, timing mechanics, and skill checks
 
-signal drill_completed(results: Dictionary)
 
 # Static function for simulating rewards without playing
-static func calculate_simulated_rewards(successes: int, attempts: int = 10) -> Dictionary:
-	var total_xp = XP_PER_ATTEMPT * attempts
-	total_xp += XP_PER_SUCCESS * successes
+static func calculate_simulated_rewards(successes_count: int, attempts: int = 10) -> Dictionary:
+	var total_xp = TrainingConstants.XP_PER_ATTEMPT * attempts
+	total_xp += XP_PER_SUCCESS * successes_count
 
 	# Quick pass bonuses (assume 30% were quick in simulation)
-	var quick_passes = roundi(successes * 0.3)
+	var quick_passes = roundi(successes_count * 0.3)
 	total_xp += XP_QUICK_PASS_BONUS * quick_passes
 
-	if successes >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if successes >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
+	if successes_count >= 7:
+		total_xp += TrainingConstants.XP_GOOD_SESSION_BONUS
+	if successes_count >= 10:
+		total_xp += TrainingConstants.XP_PERFECT_SESSION_BONUS
 
-	var pas_xp = (STAT_XP_PER_SUCCESS * successes) + (STAT_XP_PER_FAIL * (attempts - successes))
+	var pas_xp = (TrainingConstants.STAT_XP_PER_SUCCESS * successes_count) + (TrainingConstants.STAT_XP_PER_FAIL * (attempts - successes_count))
 	var tec_xp = TEC_XP_PER_ATTEMPT * attempts
 
 	return {
-		"successes": successes,
+		"successes": successes_count,
 		"attempts": attempts,
 		"total_xp": total_xp,
 		"pas_xp": pas_xp,
 		"tec_xp": tec_xp,
-		"stamina_cost": STAMINA_COST
+		"stamina_cost": TrainingConstants.STAMINA_COST
 	}
 
 
@@ -48,64 +47,47 @@ const DIFFICULTY_SETTINGS: Dictionary = {
 }
 
 # Teammate adjacency for pentagon layout
-# Position 0 is top, then clockwise: 1=top-right, 2=bottom-right, 3=bottom-left, 4=top-left
 const TEAMMATE_ADJACENCY: Dictionary = {
-	0: [1, 4],  # Top connects to upper sides
-	1: [0, 2],  # Right side
-	2: [1, 3],  # Bottom right
-	3: [2, 4],  # Bottom left
-	4: [3, 0]   # Left side
+	0: [1, 4],
+	1: [0, 2],
+	2: [1, 3],
+	3: [2, 4],
+	4: [3, 0]
 }
 
 # Pass distances - diagonal passes are "far"
 const FAR_PASSES: Array = [
-	[0, 2], [0, 3],  # Top to bottom corners
-	[1, 3], [1, 4],  # Right side to left corners
-	[2, 4]           # Bottom right to top left
+	[0, 2], [0, 3],
+	[1, 3], [1, 4],
+	[2, 4]
 ]
 
 # Distance modifiers
 const DISTANCE_MODIFIERS: Dictionary = {
-	"adjacent": 5,   # Near pass: +5%
-	"across": 0,     # Not used in pentagon (all are adjacent or far)
-	"far": -10       # Diagonal: -10%
+	"adjacent": 5,
+	"across": 0,
+	"far": -10
 }
 
 # Pressure modifiers
 const PRESSURE_MODIFIERS: Dictionary = {
-	"open": 10,       # No pressure: +10%
-	"contested": -5,  # Adjacent to defender target: -5%
-	"covered": -25    # Defender's target: -25% (risky pass!)
+	"open": 10,
+	"contested": -5,
+	"covered": -25
 }
 
 # Timing modifiers
 const TIMING_MODIFIERS: Dictionary = {
-	"quick": 10,      # >66% time remaining: +10%
-	"normal": 0,      # 33-66% time remaining: 0%
-	"late": -10       # <33% time remaining: -10%
+	"quick": 10,
+	"normal": 0,
+	"late": -10
 }
 
-# XP rewards
-const XP_PER_ATTEMPT: int = 5
+# Drill-specific XP rewards
 const XP_PER_SUCCESS: int = 8
 const XP_QUICK_PASS_BONUS: int = 3
-const XP_GOOD_SESSION_BONUS: int = 25   # 7+ successes
-const XP_PERFECT_SESSION_BONUS: int = 50  # 10/10
-const STAT_XP_PER_SUCCESS: int = 3
-const STAT_XP_PER_FAIL: int = 1
 const TEC_XP_PER_ATTEMPT: int = 2
-const STAMINA_COST: int = 15
-const ROUNDS_PER_SESSION: int = 10
-const DEFENDER_MOVE_DELAY: float = 0.8  # Time for defender to "move" to target
-
-# Console Dashboard Colors
-const BG_DARK = Color(0.039, 0.086, 0.157)
-const PANEL_BG = Color(0.06, 0.1, 0.18, 0.95)
-const BORDER_COLOR = Color(0.15, 0.25, 0.4)
-const ACCENT_GREEN = Color(0, 1, 0.5)
-const TEXT_PRIMARY = Color(0.9, 0.95, 1)
-const TEXT_SECONDARY = Color(0.6, 0.65, 0.7)
-const TEXT_MUTED = Color(0.5, 0.55, 0.6)
+const DEFENDER_MOVE_DELAY: float = 0.8
 
 # Node references
 @onready var difficulty_selector: OptionButton = $VBoxContainer/HeaderSection/DifficultyContainer/DifficultySelector
@@ -132,58 +114,84 @@ const TEXT_MUTED = Color(0.5, 0.55, 0.6)
 
 # State
 var current_state: DrillState = DrillState.SETUP
-var current_difficulty: String = "youth"
-var defender_target: int = -1  # Teammate index being covered
+var defender_target: int = -1
 var time_remaining: float = 0.0
 var max_time: float = 3.0
 
-# Session tracking
-var rounds_played: int = 0
-var successful_passes: int = 0
+# Session tracking (additional to base class)
 var quick_passes: int = 0
-var session_results: Array[Dictionary] = []
 
-# Defender pattern learning (for Pro/Elite)
+# Defender pattern learning
 var player_pass_history: Array[int] = []
 var defender_weights: Array[float] = [1.0, 1.0, 1.0, 1.0, 1.0]
 
 # Teammate button references
 var teammate_buttons: Array[Button] = []
 
-# State Colors (console theme)
-const COLOR_DEFAULT_BUTTON = Color(0.1, 0.15, 0.25)   # Dark panel
-const COLOR_COVERED = Color(0.6, 0.2, 0.2)            # Red - covered by defender
-const COLOR_CONTESTED_BUTTON = Color(0.8, 0.5, 0.2)   # Orange - contested
-const COLOR_SELECTED_BUTTON = Color(0, 0.6, 0.3)      # Green - selected
-const COLOR_SUCCESS_BUTTON = Color(0, 0.8, 0.4)       # Bright green - success
-const COLOR_FAIL_BUTTON = Color(0.3, 0.3, 0.35)       # Dark gray - fail
 
+# ===== OVERRIDES =====
+
+func _get_drill_name() -> String:
+	return "rondo"
+
+
+func _get_primary_stat() -> String:
+	return "PAS"
+
+
+func _get_secondary_stat() -> String:
+	return "TEC"
+
+
+func _get_difficulty_settings() -> Dictionary:
+	return DIFFICULTY_SETTINGS
+
+
+func _get_xp_per_success() -> int:
+	return XP_PER_SUCCESS
+
+
+func _get_success_label() -> String:
+	return "Successful Passes"
+
+
+func _is_drill_complete() -> bool:
+	return current_state == DrillState.DRILL_COMPLETE
+
+
+func _get_completion_title() -> String:
+	return "Rondo Training Complete"
+
+
+func _get_completion_message(total_xp: int) -> String:
+	return "Passed %d/%d! Earned %d XP" % [successes, attempts_taken, total_xp]
+
+
+func _calculate_bonus_xp() -> int:
+	return XP_QUICK_PASS_BONUS * quick_passes
+
+
+func _get_bonus_xp_breakdown() -> String:
+	if quick_passes > 0:
+		return "Quick Bonus: +%d XP (%d × %d)\n" % [XP_QUICK_PASS_BONUS * quick_passes, quick_passes, XP_QUICK_PASS_BONUS]
+	return ""
+
+
+func _calculate_secondary_stat_xp(_xp_per_attempt: int = 2) -> int:
+	return TEC_XP_PER_ATTEMPT * attempts_taken
+
+
+# ===== SETUP =====
 
 func _ready() -> void:
-	_setup_difficulty_selector()
+	_setup_difficulty_selector(difficulty_selector)
 	_setup_teammate_buttons()
 	_setup_signals()
-	_style_footer_buttons()
+	_style_footer_buttons(continue_button, exit_button)
 	_update_player_stats_display()
-	_show_session_start_narration()
+	_show_session_start_narration(narration_label)
 	_set_state(DrillState.DEFENDING)
 	_start_new_round()
-
-
-func _setup_difficulty_selector() -> void:
-	difficulty_selector.clear()
-	var idx = 0
-	for diff_id in DIFFICULTY_SETTINGS:
-		var diff = DIFFICULTY_SETTINGS[diff_id]
-		var text = diff.name
-		if not diff.unlocked:
-			text += " (Locked)"
-		difficulty_selector.add_item(text, idx)
-		if not diff.unlocked:
-			difficulty_selector.set_item_disabled(idx, true)
-		idx += 1
-	difficulty_selector.selected = 0
-	difficulty_selector.item_selected.connect(_on_difficulty_changed)
 
 
 func _setup_teammate_buttons() -> void:
@@ -193,55 +201,13 @@ func _setup_teammate_buttons() -> void:
 		if btn:
 			teammate_buttons.append(btn)
 			btn.pressed.connect(_on_teammate_pressed.bind(i))
-			_set_button_color(btn, COLOR_DEFAULT_BUTTON)
+			_set_button_style(btn, TrainingConstants.COLOR_DEFAULT)
 
 
 func _setup_signals() -> void:
 	continue_button.pressed.connect(_on_continue_pressed)
 	exit_button.pressed.connect(_on_exit_pressed)
 	round_timer.timeout.connect(_on_timer_tick)
-
-
-func _style_footer_buttons() -> void:
-	# Style Continue button with console green accent
-	var continue_style = StyleBoxFlat.new()
-	continue_style.bg_color = Color(0, 0.6, 0.3)
-	continue_style.border_width_left = 2
-	continue_style.border_width_top = 2
-	continue_style.border_width_right = 2
-	continue_style.border_width_bottom = 2
-	continue_style.border_color = Color(0, 0.8, 0.4)
-	continue_style.set_corner_radius_all(6)
-	continue_button.add_theme_stylebox_override("normal", continue_style)
-	continue_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var continue_hover = continue_style.duplicate()
-	continue_hover.bg_color = Color(0, 0.7, 0.35)
-	continue_button.add_theme_stylebox_override("hover", continue_hover)
-
-	var continue_pressed = continue_style.duplicate()
-	continue_pressed.bg_color = Color(0, 0.5, 0.25)
-	continue_button.add_theme_stylebox_override("pressed", continue_pressed)
-
-	# Style Exit button with dark panel style
-	var exit_style = StyleBoxFlat.new()
-	exit_style.bg_color = COLOR_DEFAULT_BUTTON
-	exit_style.border_width_left = 2
-	exit_style.border_width_top = 2
-	exit_style.border_width_right = 2
-	exit_style.border_width_bottom = 2
-	exit_style.border_color = BORDER_COLOR
-	exit_style.set_corner_radius_all(6)
-	exit_button.add_theme_stylebox_override("normal", exit_style)
-	exit_button.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-	var exit_hover = exit_style.duplicate()
-	exit_hover.bg_color = Color(0.15, 0.2, 0.3)
-	exit_button.add_theme_stylebox_override("hover", exit_hover)
-
-	var exit_pressed = exit_style.duplicate()
-	exit_pressed.bg_color = Color(0.08, 0.12, 0.2)
-	exit_button.add_theme_stylebox_override("pressed", exit_pressed)
 
 
 func _update_player_stats_display() -> void:
@@ -261,6 +227,8 @@ func _update_player_stats_display() -> void:
 func _calculate_base_chance(pas: int, tec: int) -> float:
 	return (pas * 0.7) + (tec * 0.3)
 
+
+# ===== STATE MANAGEMENT =====
 
 func _set_state(new_state: DrillState) -> void:
 	current_state = new_state
@@ -294,28 +262,25 @@ func _enable_teammate_buttons(enabled: bool) -> void:
 		btn.disabled = not enabled
 
 
-func _start_new_round() -> void:
-	# Reset button colors
-	for i in range(teammate_buttons.size()):
-		_set_button_color(teammate_buttons[i], COLOR_DEFAULT_BUTTON)
+# ===== ROUND MANAGEMENT =====
 
-	# Pick defender target
+func _start_new_round() -> void:
+	for i in range(teammate_buttons.size()):
+		_set_button_style(teammate_buttons[i], TrainingConstants.COLOR_DEFAULT)
+
 	_select_defender_target()
 
-	# Update UI to show defender moving
 	defender_indicator.text = "[DEF]"
 	target_label.text = "Defender moving..."
 	pressure_label.text = "..."
 	_clear_modifiers_display()
 
-	# Move to defending state with delay
 	_set_state(DrillState.DEFENDING)
 
-	# After delay, start the passing phase
 	await get_tree().create_timer(DEFENDER_MOVE_DELAY).timeout
 
 	if current_state != DrillState.DEFENDING:
-		return  # State changed (e.g., exited)
+		return
 
 	_position_defender()
 	_update_teammate_colors()
@@ -326,10 +291,8 @@ func _select_defender_target() -> void:
 	var diff = DIFFICULTY_SETTINGS[current_difficulty]
 
 	if diff.learning_rate <= 0.0 or player_pass_history.is_empty():
-		# Random target for Youth difficulty or first round
 		defender_target = randi() % 5
 	else:
-		# Weighted selection based on player patterns
 		var total_weight = 0.0
 		for w in defender_weights:
 			total_weight += w
@@ -345,12 +308,10 @@ func _select_defender_target() -> void:
 
 
 func _position_defender() -> void:
-	# Move defender indicator near the target teammate button
 	var target_btn = teammate_buttons[defender_target]
 	var btn_pos = target_btn.position
 	var btn_size = target_btn.size
 
-	# Position defender indicator near the target (offset slightly toward center)
 	var center = Vector2(160, 140)
 	var direction_to_center = (center - (btn_pos + btn_size / 2)).normalized()
 	var defender_pos = btn_pos + btn_size / 2 + direction_to_center * 30 - Vector2(30, 15)
@@ -368,13 +329,12 @@ func _update_teammate_colors() -> void:
 
 		match pressure:
 			"covered":
-				_set_button_color(btn, COLOR_COVERED)
+				_set_button_style(btn, TrainingConstants.COLOR_BLOCKED)
 			"contested":
-				_set_button_color(btn, COLOR_CONTESTED_BUTTON)
+				_set_button_style(btn, TrainingConstants.COLOR_CONTESTED)
 			_:
-				_set_button_color(btn, COLOR_DEFAULT_BUTTON)
+				_set_button_style(btn, TrainingConstants.COLOR_DEFAULT)
 
-	# Update info panel
 	target_label.text = "Defender on: T%d" % (defender_target + 1)
 	var contested_list = _get_contested_teammates(diff)
 	if contested_list.is_empty():
@@ -391,12 +351,10 @@ func _get_contested_teammates(diff: Dictionary) -> Array:
 	if radius <= 0:
 		return contested
 
-	# Get adjacent teammates to defender target
 	var adjacent = TEAMMATE_ADJACENCY.get(defender_target, [])
 	for adj in adjacent:
 		contested.append(adj)
 
-		# Elite difficulty: also pressure teammates adjacent to adjacent
 		if radius >= 2:
 			var second_level = TEAMMATE_ADJACENCY.get(adj, [])
 			for sl in second_level:
@@ -424,11 +382,13 @@ func _start_passing_phase() -> void:
 
 	timer_label.text = "Time: %.1fs" % time_remaining
 	timer_bar.value = 100.0
-	_update_timer_bar_color()
+	_update_timer_bar_color(timer_bar, time_remaining, max_time)
 
 	_set_state(DrillState.PASSING)
 	round_timer.start()
 
+
+# ===== TIMER =====
 
 func _on_timer_tick() -> void:
 	if current_state != DrillState.PASSING:
@@ -444,38 +404,8 @@ func _on_timer_tick() -> void:
 	timer_label.text = "Time: %.1fs" % time_remaining
 	var pct = (time_remaining / max_time) * 100.0
 	timer_bar.value = pct
-	_update_timer_bar_color()
-
-	# Update timing modifier display
+	_update_timer_bar_color(timer_bar, time_remaining, max_time)
 	_update_timing_display()
-
-
-func _update_timer_bar_color() -> void:
-	var pct = time_remaining / max_time
-	var color: Color
-
-	if pct > 0.66:
-		color = Color(0, 0.8, 0.4)  # Console green
-	elif pct > 0.33:
-		color = Color(0.9, 0.7, 0.2)  # Amber
-	else:
-		color = Color(0.8, 0.3, 0.3)  # Darker red
-
-	var fill_style = StyleBoxFlat.new()
-	fill_style.bg_color = color
-	fill_style.set_corner_radius_all(4)
-	timer_bar.add_theme_stylebox_override("fill", fill_style)
-
-	# Set dark background for timer bar
-	var bg_style = StyleBoxFlat.new()
-	bg_style.bg_color = Color(0.1, 0.15, 0.25)
-	bg_style.border_width_left = 1
-	bg_style.border_width_top = 1
-	bg_style.border_width_right = 1
-	bg_style.border_width_bottom = 1
-	bg_style.border_color = BORDER_COLOR
-	bg_style.set_corner_radius_all(4)
-	timer_bar.add_theme_stylebox_override("background", bg_style)
 
 
 func _get_timing_level() -> String:
@@ -512,17 +442,19 @@ func _handle_timeout() -> void:
 		"roll": 0
 	}
 
-	rounds_played += 1
+	attempts_taken += 1
 	session_results.append(result)
 
 	_display_timeout_result()
-	_update_score_display()
+	_update_score()
 
-	if rounds_played >= ROUNDS_PER_SESSION:
+	if attempts_taken >= TrainingConstants.ATTEMPTS_PER_SESSION:
 		_complete_drill()
 	else:
 		_set_state(DrillState.SHOWING_RESULT)
 
+
+# ===== EVENT HANDLERS =====
 
 func _on_teammate_pressed(teammate_idx: int) -> void:
 	if current_state != DrillState.PASSING:
@@ -535,6 +467,33 @@ func _on_teammate_pressed(teammate_idx: int) -> void:
 	_resolve_pass(teammate_idx)
 
 
+func _on_continue_pressed() -> void:
+	if current_state == DrillState.SHOWING_RESULT:
+		AudioManager.play_ui_click()
+		skill_check_details.text = "Click a teammate to pass..."
+		_clear_modifiers_display()
+		_start_new_round()
+
+
+func _on_exit_pressed() -> void:
+	_handle_exit()
+
+
+# ===== UI HELPERS =====
+
+func _clear_modifiers_display() -> void:
+	distance_mod_label.text = "Distance: --"
+	pressure_mod_label.text = "Pressure: --"
+	timing_mod_label.text = "Timing: --"
+	final_chance_label.text = "Final: --%"
+
+
+func _update_score() -> void:
+	_update_score_display(score_label, round_counter, "Round")
+
+
+# ===== RESOLUTION =====
+
 func _resolve_pass(teammate_idx: int) -> void:
 	var player = GameManager.player_data
 	if not player:
@@ -544,7 +503,6 @@ func _resolve_pass(teammate_idx: int) -> void:
 	var pas = player.get_effective_stat("PAS")
 	var tec = player.get_effective_stat("TEC")
 
-	# Calculate success chance
 	var base_chance = _calculate_base_chance(pas, tec)
 	var distance_mod = _get_distance_modifier(teammate_idx)
 	var pressure = _get_pressure_level(teammate_idx, diff)
@@ -555,7 +513,6 @@ func _resolve_pass(teammate_idx: int) -> void:
 	var final_chance = base_chance + distance_mod + pressure_mod + timing_mod
 	final_chance = clampf(final_chance, 5.0, 95.0)
 
-	# Roll for success
 	var roll = randf() * 100.0
 	var success = roll <= final_chance
 
@@ -576,44 +533,32 @@ func _resolve_pass(teammate_idx: int) -> void:
 		"risky_pass": pressure == "covered"
 	}
 
-	# Update learning for Pro/Elite difficulty
 	player_pass_history.append(teammate_idx)
 	_update_defender_weights(diff.learning_rate)
 
-	# Track results
-	rounds_played += 1
+	attempts_taken += 1
 	if success:
-		successful_passes += 1
+		successes += 1
 		if timing == "quick":
 			quick_passes += 1
 	session_results.append(result)
 
-	# Show result
 	_display_pass_result(result, teammate_idx)
-	_update_score_display()
+	_update_score()
 
-	if rounds_played >= ROUNDS_PER_SESSION:
+	if attempts_taken >= TrainingConstants.ATTEMPTS_PER_SESSION:
 		_complete_drill()
 	else:
 		_set_state(DrillState.SHOWING_RESULT)
 
 
 func _get_distance_type(teammate_idx: int) -> String:
-	# Check if it's a far (diagonal) pass
 	for pair in FAR_PASSES:
-		if (pair[0] == 0 and pair[1] == teammate_idx) or (pair[1] == 0 and pair[0] == teammate_idx):
-			# This simplified check assumes player is at center, all passes originate from center
-			pass
-		# Actually check if target is far from any starting position
-		# In rondo, we consider diagonal across pentagon as "far"
 		if teammate_idx in [pair[0], pair[1]]:
-			# Check if this is a diagonal relationship
 			var other = pair[0] if pair[1] == teammate_idx else pair[1]
-			# Far passes are non-adjacent in the pentagon
 			if other not in TEAMMATE_ADJACENCY.get(teammate_idx, []):
 				return "far"
 
-	# If not far, check adjacency (all positions are "adjacent" to the center player)
 	return "adjacent"
 
 
@@ -626,7 +571,6 @@ func _update_defender_weights(learning_rate: float) -> void:
 	if learning_rate <= 0.0 or player_pass_history.is_empty():
 		return
 
-	# Count pass frequencies
 	var counts: Array[int] = [0, 0, 0, 0, 0]
 	for target in player_pass_history:
 		if target >= 0 and target < 5:
@@ -634,7 +578,6 @@ func _update_defender_weights(learning_rate: float) -> void:
 
 	var total = player_pass_history.size()
 
-	# Update weights based on frequency
 	for i in range(5):
 		var frequency = float(counts[i]) / total
 		var target_weight = 1.0 + (frequency * 3.0)
@@ -645,11 +588,10 @@ func _display_pass_result(result: Dictionary, teammate_idx: int) -> void:
 	var btn = teammate_buttons[teammate_idx]
 
 	if result.success:
-		_set_button_color(btn, COLOR_SUCCESS_BUTTON)
+		_set_button_style(btn, TrainingConstants.COLOR_SUCCESS)
 	else:
-		_set_button_color(btn, COLOR_FAIL_BUTTON)
+		_set_button_style(btn, Color(0.3, 0.3, 0.35))
 
-	# Build skill check breakdown
 	var breakdown = ""
 	breakdown += "[b]Pass Calculation:[/b]\n"
 	breakdown += "Base: (PAS x 0.7) + (TEC x 0.3) = %.1f%%\n" % result.base_chance
@@ -668,15 +610,12 @@ func _display_pass_result(result: Dictionary, teammate_idx: int) -> void:
 		breakdown += "\n[color=red][b]INTERCEPTED![/b][/color]"
 
 	skill_check_details.text = breakdown
-
-	# Show narration
 	_show_pass_narration(result)
 
 
 func _display_timeout_result() -> void:
-	# Gray out all buttons
 	for btn in teammate_buttons:
-		_set_button_color(btn, COLOR_FAIL_BUTTON)
+		_set_button_style(btn, Color(0.3, 0.3, 0.35))
 
 	var breakdown = "[b]TIMEOUT![/b]\n\n"
 	breakdown += "You held onto the ball too long.\n"
@@ -685,7 +624,6 @@ func _display_timeout_result() -> void:
 
 	skill_check_details.text = breakdown
 
-	# Show timeout narration
 	var narrative = NarrativeEngine.generate_dialogue("rondo", "timeout", {})
 	narration_label.text = "[i]%s[/i]" % narrative.text
 
@@ -710,171 +648,27 @@ func _show_pass_narration(result: Dictionary) -> void:
 	narration_label.text = "[i]%s[/i]" % narrative.text
 
 
-func _clear_modifiers_display() -> void:
-	distance_mod_label.text = "Distance: --"
-	pressure_mod_label.text = "Pressure: --"
-	timing_mod_label.text = "Timing: --"
-	final_chance_label.text = "Final: --%"
-
-
-func _update_score_display() -> void:
-	score_label.text = "%d / %d" % [successful_passes, ROUNDS_PER_SESSION]
-	round_counter.text = "Round %d of %d" % [mini(rounds_played + 1, ROUNDS_PER_SESSION), ROUNDS_PER_SESSION]
-
-
 func _complete_drill() -> void:
 	_set_state(DrillState.DRILL_COMPLETE)
 
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * rounds_played
-	total_xp += XP_PER_SUCCESS * successful_passes
-	total_xp += XP_QUICK_PASS_BONUS * quick_passes
-
-	if successful_passes >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if successful_passes >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var pas_xp = (STAT_XP_PER_SUCCESS * successful_passes) + (STAT_XP_PER_FAIL * (rounds_played - successful_passes))
-	var tec_xp = TEC_XP_PER_ATTEMPT * rounds_played
-
-	# Build summary
-	var summary = "[b]Drill Complete![/b]\n\n"
-	summary += "Successful Passes: %d / %d (%.0f%%)\n" % [successful_passes, rounds_played, (float(successful_passes) / rounds_played) * 100]
-	summary += "Quick Passes: %d\n\n" % quick_passes
-	summary += "[b]XP Earned:[/b]\n"
-	summary += "Base: %d XP (%d attempts x %d)\n" % [XP_PER_ATTEMPT * rounds_played, rounds_played, XP_PER_ATTEMPT]
-	summary += "Successes: +%d XP (%d x %d)\n" % [XP_PER_SUCCESS * successful_passes, successful_passes, XP_PER_SUCCESS]
-	summary += "Quick Bonus: +%d XP (%d x %d)\n" % [XP_QUICK_PASS_BONUS * quick_passes, quick_passes, XP_QUICK_PASS_BONUS]
-
-	if successful_passes >= 10:
-		summary += "Perfect Session: +%d XP\n" % XP_PERFECT_SESSION_BONUS
-	elif successful_passes >= 7:
-		summary += "Good Session: +%d XP\n" % XP_GOOD_SESSION_BONUS
-
-	summary += "[b]Total: %d XP[/b]\n\n" % total_xp
-	summary += "[b]Stat XP:[/b]\n"
-	summary += "PAS: +%d\n" % pas_xp
-	summary += "TEC: +%d\n" % tec_xp
+	var summary = _build_xp_summary()
+	summary = summary.replace("Successful Passes: %d / %d" % [successes, attempts_taken],
+		"Successful Passes: %d / %d (%.0f%%)\nQuick Passes: %d" % [
+			successes, attempts_taken,
+			(float(successes) / attempts_taken) * 100,
+			quick_passes
+		])
 
 	skill_check_details.text = summary
-
-	# Show session end narration
-	var context = {"successes": str(successful_passes), "total": str(rounds_played)}
-	var narrative = NarrativeEngine.generate_dialogue("rondo", "session_end", context)
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-	# Store results
-	var results = {
-		"rounds_played": rounds_played,
-		"successful_passes": successful_passes,
-		"quick_passes": quick_passes,
-		"accuracy": float(successful_passes) / rounds_played,
-		"total_xp": total_xp,
-		"pas_xp": pas_xp,
-		"tec_xp": tec_xp,
-		"session_results": session_results
-	}
-
-	# Save best score
+	_show_session_end_narration(narration_label)
 	_save_best_score()
-
-	drill_completed.emit(results)
-
-
-func _save_best_score() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	var current_record = player.training_records.get("rondo_drill", {})
-	var previous_best = current_record.get("best_score", 0)
-
-	if successful_passes > previous_best:
-		player.training_records["rondo_drill"] = {
-			"best_score": successful_passes,
-			"attempts": ROUNDS_PER_SESSION,
-			"best_accuracy": float(successful_passes) / ROUNDS_PER_SESSION
-		}
-
-
-func _show_session_start_narration() -> void:
-	var narrative = NarrativeEngine.generate_dialogue("rondo", "session_start", {})
-	narration_label.text = "[i]%s[/i]" % narrative.text
-
-
-func _set_button_color(btn: Button, color: Color) -> void:
-	var style = StyleBoxFlat.new()
-	style.bg_color = color
-	style.border_width_left = 2
-	style.border_width_top = 2
-	style.border_width_right = 2
-	style.border_width_bottom = 2
-	style.border_color = BORDER_COLOR
-	style.set_corner_radius_all(6)
-	btn.add_theme_stylebox_override("normal", style)
-	btn.add_theme_stylebox_override("hover", style)
-	btn.add_theme_stylebox_override("pressed", style)
-	btn.add_theme_color_override("font_color", TEXT_PRIMARY)
-
-
-func _on_difficulty_changed(index: int) -> void:
-	var keys = DIFFICULTY_SETTINGS.keys()
-	if index < keys.size():
-		current_difficulty = keys[index]
-	AudioManager.play_ui_click()
-
-
-func _on_continue_pressed() -> void:
-	if current_state == DrillState.SHOWING_RESULT:
-		AudioManager.play_ui_click()
-		skill_check_details.text = "Click a teammate to pass..."
-		_clear_modifiers_display()
-		_start_new_round()
-
-
-func _on_exit_pressed() -> void:
-	AudioManager.play_ui_click()
-
-	# Apply rewards if drill was completed
-	if current_state == DrillState.DRILL_COMPLETE:
-		_apply_rewards()
-
-	# Return to console dashboard
-	get_tree().change_scene_to_file("res://scenes/dashboard/console_dashboard.tscn")
-
-
-func _apply_rewards() -> void:
-	var player = GameManager.player_data
-	if not player:
-		return
-
-	# Calculate rewards
-	var total_xp = XP_PER_ATTEMPT * rounds_played
-	total_xp += XP_PER_SUCCESS * successful_passes
-	total_xp += XP_QUICK_PASS_BONUS * quick_passes
-
-	if successful_passes >= 7:
-		total_xp += XP_GOOD_SESSION_BONUS
-	if successful_passes >= 10:
-		total_xp += XP_PERFECT_SESSION_BONUS
-
-	var pas_xp = (STAT_XP_PER_SUCCESS * successful_passes) + (STAT_XP_PER_FAIL * (rounds_played - successful_passes))
-	var tec_xp = TEC_XP_PER_ATTEMPT * rounds_played
-
-	# Apply to player
-	player.stamina_current = maxi(player.stamina_current - STAMINA_COST, 0)
-	player.add_xp(total_xp)
-	player.add_stat_xp("PAS", pas_xp)
-	player.add_stat_xp("TEC", tec_xp)
-
-	# Advance time
-	DesktopManager.advance_time(1)
-
-	# Show notification
-	DesktopManager.show_notification(
-		"Rondo Training Complete",
-		"Passed %d/%d! Earned %d XP" % [successful_passes, rounds_played, total_xp],
-		"",
-		"training"
-	)
+	drill_completed.emit({
+		"rounds_played": attempts_taken,
+		"successful_passes": successes,
+		"quick_passes": quick_passes,
+		"accuracy": float(successes) / attempts_taken,
+		"total_xp": _calculate_total_xp(),
+		"pas_xp": _calculate_primary_stat_xp(),
+		"tec_xp": _calculate_secondary_stat_xp(),
+		"session_results": session_results
+	})

--- a/scripts/training/training_constants.gd
+++ b/scripts/training/training_constants.gd
@@ -1,0 +1,76 @@
+class_name TrainingConstants
+## Shared constants for all training drills
+
+# Console Dashboard Colors
+const BG_DARK = Color(0.039, 0.086, 0.157)
+const PANEL_BG = Color(0.06, 0.1, 0.18, 0.95)
+const BORDER_COLOR = Color(0.15, 0.25, 0.4)
+const ACCENT_GREEN = Color(0, 1, 0.5)
+const TEXT_PRIMARY = Color(0.9, 0.95, 1)
+const TEXT_SECONDARY = Color(0.6, 0.65, 0.7)
+const TEXT_MUTED = Color(0.5, 0.55, 0.6)
+
+# State Colors
+const COLOR_DEFAULT = Color(0.1, 0.15, 0.25)
+const COLOR_SELECTED = Color(0, 0.6, 0.3)
+const COLOR_SUCCESS = Color(0, 0.8, 0.4)
+const COLOR_FAIL = Color(0.8, 0.3, 0.3)
+const COLOR_WARNING = Color(0.9, 0.7, 0.2)
+const COLOR_BLOCKED = Color(0.6, 0.2, 0.2)
+const COLOR_CONTESTED = Color(0.8, 0.5, 0.2)
+const COLOR_OPEN = Color(0.2, 0.5, 0.8)
+
+# XP Rewards (base values)
+const XP_PER_ATTEMPT: int = 5
+const XP_GOOD_SESSION_BONUS: int = 25
+const XP_PERFECT_SESSION_BONUS: int = 50
+const STAT_XP_PER_SUCCESS: int = 3
+const STAT_XP_PER_FAIL: int = 1
+const STAMINA_COST: int = 15
+const ATTEMPTS_PER_SESSION: int = 10
+
+# Power bar ranges (shared by freekick and penalty)
+const POWER_RANGES: Array[Dictionary] = [
+	{"min": 0, "max": 39, "name": "Weak", "modifier": -15},
+	{"min": 40, "max": 69, "name": "Good", "modifier": 0},
+	{"min": 70, "max": 85, "name": "Optimal", "modifier": 5},
+	{"min": 86, "max": 100, "name": "Overpowered", "modifier": -10}
+]
+
+# Zone modifiers (shared by freekick and penalty)
+const ZONE_MODIFIERS: Dictionary = {
+	"TOP_LEFT": -20, "TOP_CENTER": -15, "TOP_RIGHT": -20,
+	"MID_LEFT": -10, "MID_CENTER": 5, "MID_RIGHT": -10,
+	"LOW_LEFT": -10, "LOW_CENTER": -5, "LOW_RIGHT": -10
+}
+
+# Zone names for iteration
+const ZONE_NAMES: Array[String] = [
+	"TOP_LEFT", "TOP_CENTER", "TOP_RIGHT",
+	"MID_LEFT", "MID_CENTER", "MID_RIGHT",
+	"LOW_LEFT", "LOW_CENTER", "LOW_RIGHT"
+]
+
+const ZONE_BUTTON_NAMES: Array[String] = [
+	"TopLeft", "TopCenter", "TopRight",
+	"MidLeft", "MidCenter", "MidRight",
+	"LowLeft", "LowCenter", "LowRight"
+]
+
+# Charge rate for power bar (100% in 1.5 seconds)
+const CHARGE_RATE: float = 66.67
+
+
+# Helper to get power modifier from power value
+static func get_power_modifier(power: float) -> int:
+	for range_data in POWER_RANGES:
+		if power >= range_data.min and power <= range_data.max:
+			return range_data.modifier
+	return 0
+
+
+static func get_power_name(power: float) -> String:
+	for range_data in POWER_RANGES:
+		if power >= range_data.min and power <= range_data.max:
+			return range_data.name
+	return "Unknown"

--- a/scripts/training/training_drill_base.gd
+++ b/scripts/training/training_drill_base.gd
@@ -1,0 +1,368 @@
+class_name TrainingDrillBase
+extends Control
+## Abstract base class for training drills
+## Provides shared functionality for difficulty selection, XP rewards, button styling, etc.
+
+signal drill_completed(results: Dictionary)
+
+# ===== VIRTUAL METHODS - Override in subclasses =====
+
+## Returns the drill identifier (e.g., "freekick", "penalty", "rondo")
+func _get_drill_name() -> String:
+	return "drill"
+
+
+## Returns the primary stat trained by this drill
+func _get_primary_stat() -> String:
+	return "SHO"
+
+
+## Returns the secondary stat trained by this drill
+func _get_secondary_stat() -> String:
+	return "TEC"
+
+
+## Returns the difficulty settings dictionary for this drill
+func _get_difficulty_settings() -> Dictionary:
+	return {}
+
+
+## Returns XP earned per successful attempt
+func _get_xp_per_success() -> int:
+	return 10
+
+
+## Returns additional bonus XP (e.g., top corner bonus, quick pass bonus)
+func _calculate_bonus_xp() -> int:
+	return 0
+
+
+## Returns the label for successes (e.g., "Goals", "Successful Passes")
+func _get_success_label() -> String:
+	return "Successes"
+
+
+## Returns true if the drill is in a completed state
+func _is_drill_complete() -> bool:
+	return false
+
+
+## Called when showing the completion notification
+func _get_completion_title() -> String:
+	return "Training Complete"
+
+
+## Called when showing the completion notification
+func _get_completion_message(total_xp: int) -> String:
+	return "Scored %d/%d! Earned %d XP" % [successes, attempts_taken, total_xp]
+
+
+# ===== SHARED STATE =====
+
+var current_difficulty: String = "youth"
+var attempts_taken: int = 0
+var successes: int = 0
+var session_results: Array[Dictionary] = []
+
+
+# ===== SHARED IMPLEMENTATIONS =====
+
+## Sets up the difficulty selector dropdown
+func _setup_difficulty_selector(selector: OptionButton) -> void:
+	selector.clear()
+	var idx = 0
+	var settings = _get_difficulty_settings()
+	for diff_id in settings:
+		var diff = settings[diff_id]
+		var text = diff.name
+		if not diff.get("unlocked", true):
+			text += " (Locked)"
+		selector.add_item(text, idx)
+		if not diff.get("unlocked", true):
+			selector.set_item_disabled(idx, true)
+		idx += 1
+	selector.selected = 0
+	selector.item_selected.connect(_on_difficulty_changed)
+
+
+## Handles difficulty selection change
+func _on_difficulty_changed(index: int) -> void:
+	var keys = _get_difficulty_settings().keys()
+	if index < keys.size():
+		current_difficulty = keys[index]
+	AudioManager.play_ui_click()
+
+
+## Creates a StyleBoxFlat with the given colors
+func _create_button_style(bg_color: Color, border_color: Color, corner_radius: int = 6) -> StyleBoxFlat:
+	var style = StyleBoxFlat.new()
+	style.bg_color = bg_color
+	style.border_width_left = 2
+	style.border_width_top = 2
+	style.border_width_right = 2
+	style.border_width_bottom = 2
+	style.border_color = border_color
+	style.set_corner_radius_all(corner_radius)
+	return style
+
+
+## Styles the continue and exit buttons with console theme
+func _style_footer_buttons(continue_btn: Button, exit_btn: Button) -> void:
+	# Style Continue button with console green accent
+	var continue_style = _create_button_style(Color(0, 0.6, 0.3), Color(0, 0.8, 0.4))
+	continue_btn.add_theme_stylebox_override("normal", continue_style)
+	continue_btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+	var continue_hover = continue_style.duplicate()
+	continue_hover.bg_color = Color(0, 0.7, 0.35)
+	continue_btn.add_theme_stylebox_override("hover", continue_hover)
+
+	var continue_pressed = continue_style.duplicate()
+	continue_pressed.bg_color = Color(0, 0.5, 0.25)
+	continue_btn.add_theme_stylebox_override("pressed", continue_pressed)
+
+	# Style Exit button with dark panel style
+	var exit_style = _create_button_style(TrainingConstants.COLOR_DEFAULT, TrainingConstants.BORDER_COLOR)
+	exit_btn.add_theme_stylebox_override("normal", exit_style)
+	exit_btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+	var exit_hover = exit_style.duplicate()
+	exit_hover.bg_color = Color(0.15, 0.2, 0.3)
+	exit_btn.add_theme_stylebox_override("hover", exit_hover)
+
+	var exit_pressed = exit_style.duplicate()
+	exit_pressed.bg_color = Color(0.08, 0.12, 0.2)
+	exit_btn.add_theme_stylebox_override("pressed", exit_pressed)
+
+
+## Styles a shoot/action button with console theme
+func _style_shoot_button(btn: Button) -> void:
+	var shoot_style = _create_button_style(TrainingConstants.COLOR_DEFAULT, TrainingConstants.ACCENT_GREEN)
+	btn.add_theme_stylebox_override("normal", shoot_style)
+	btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+	var shoot_hover = shoot_style.duplicate()
+	shoot_hover.bg_color = Color(0.15, 0.2, 0.3)
+	btn.add_theme_stylebox_override("hover", shoot_hover)
+
+	var shoot_pressed = shoot_style.duplicate()
+	shoot_pressed.bg_color = Color(0, 0.5, 0.25)
+	btn.add_theme_stylebox_override("pressed", shoot_pressed)
+
+	var shoot_disabled = shoot_style.duplicate()
+	shoot_disabled.bg_color = Color(0.08, 0.1, 0.15)
+	shoot_disabled.border_color = Color(0.2, 0.25, 0.35)
+	btn.add_theme_stylebox_override("disabled", shoot_disabled)
+	btn.add_theme_color_override("font_disabled_color", TrainingConstants.TEXT_MUTED)
+
+
+## Updates power bar color based on current power value
+func _update_power_bar_color(power_bar: ProgressBar, power: float) -> void:
+	var color: Color
+	if power < 40:
+		color = TrainingConstants.COLOR_FAIL
+	elif power < 70:
+		color = TrainingConstants.COLOR_WARNING
+	elif power <= 85:
+		color = TrainingConstants.COLOR_SUCCESS
+	else:
+		color = TrainingConstants.COLOR_CONTESTED
+
+	var fill_style = StyleBoxFlat.new()
+	fill_style.bg_color = color
+	fill_style.set_corner_radius_all(4)
+	power_bar.add_theme_stylebox_override("fill", fill_style)
+
+	var bg_style = StyleBoxFlat.new()
+	bg_style.bg_color = TrainingConstants.COLOR_DEFAULT
+	bg_style.border_width_left = 1
+	bg_style.border_width_top = 1
+	bg_style.border_width_right = 1
+	bg_style.border_width_bottom = 1
+	bg_style.border_color = TrainingConstants.BORDER_COLOR
+	bg_style.set_corner_radius_all(4)
+	power_bar.add_theme_stylebox_override("background", bg_style)
+
+
+## Updates timer bar color based on time remaining percentage
+func _update_timer_bar_color(timer_bar: ProgressBar, time_remaining: float, max_time: float) -> void:
+	var pct = time_remaining / max_time
+	var color: Color
+
+	if pct > 0.66:
+		color = TrainingConstants.COLOR_SUCCESS
+	elif pct > 0.33:
+		color = TrainingConstants.COLOR_WARNING
+	else:
+		color = TrainingConstants.COLOR_FAIL
+
+	var fill_style = StyleBoxFlat.new()
+	fill_style.bg_color = color
+	fill_style.set_corner_radius_all(4)
+	timer_bar.add_theme_stylebox_override("fill", fill_style)
+
+	var bg_style = StyleBoxFlat.new()
+	bg_style.bg_color = TrainingConstants.COLOR_DEFAULT
+	bg_style.border_width_left = 1
+	bg_style.border_width_top = 1
+	bg_style.border_width_right = 1
+	bg_style.border_width_bottom = 1
+	bg_style.border_color = TrainingConstants.BORDER_COLOR
+	bg_style.set_corner_radius_all(4)
+	timer_bar.add_theme_stylebox_override("background", bg_style)
+
+
+## Sets color for a zone/teammate button
+func _set_button_style(btn: Button, bg_color: Color, border_color: Color = TrainingConstants.BORDER_COLOR) -> void:
+	var style = _create_button_style(bg_color, border_color)
+	btn.add_theme_stylebox_override("normal", style)
+	btn.add_theme_stylebox_override("hover", style)
+	btn.add_theme_stylebox_override("pressed", style)
+	btn.add_theme_color_override("font_color", TrainingConstants.TEXT_PRIMARY)
+
+
+## Calculates total XP earned from the session
+func _calculate_total_xp() -> int:
+	var total = TrainingConstants.XP_PER_ATTEMPT * attempts_taken
+	total += _get_xp_per_success() * successes
+	total += _calculate_bonus_xp()
+
+	if successes >= 7:
+		total += TrainingConstants.XP_GOOD_SESSION_BONUS
+	if successes >= 10:
+		total += TrainingConstants.XP_PERFECT_SESSION_BONUS
+
+	return total
+
+
+## Calculates stat XP for primary or secondary stat
+func _calculate_primary_stat_xp() -> int:
+	return (TrainingConstants.STAT_XP_PER_SUCCESS * successes) + (TrainingConstants.STAT_XP_PER_FAIL * (attempts_taken - successes))
+
+
+## Calculates secondary stat XP (typically per attempt)
+func _calculate_secondary_stat_xp(xp_per_attempt: int = 2) -> int:
+	return xp_per_attempt * attempts_taken
+
+
+## Applies rewards to the player after drill completion
+func _apply_rewards() -> void:
+	var player = GameManager.player_data
+	if not player:
+		return
+
+	var total_xp = _calculate_total_xp()
+	var primary_xp = _calculate_primary_stat_xp()
+	var secondary_xp = _calculate_secondary_stat_xp()
+
+	player.stamina_current = maxi(player.stamina_current - TrainingConstants.STAMINA_COST, 0)
+	player.add_xp(total_xp)
+	player.add_stat_xp(_get_primary_stat(), primary_xp)
+	player.add_stat_xp(_get_secondary_stat(), secondary_xp)
+
+	DesktopManager.advance_time(1)
+
+	DesktopManager.show_notification(
+		_get_completion_title(),
+		_get_completion_message(total_xp),
+		"",
+		"training"
+	)
+
+
+## Saves the best score to player training records
+func _save_best_score() -> void:
+	var player = GameManager.player_data
+	if not player:
+		return
+
+	var record_key = _get_drill_name() + "_drill"
+	var current_record = player.training_records.get(record_key, {})
+	var previous_best = current_record.get("best_score", 0)
+
+	if successes > previous_best:
+		player.training_records[record_key] = {
+			"best_score": successes,
+			"attempts": TrainingConstants.ATTEMPTS_PER_SESSION,
+			"best_accuracy": float(successes) / TrainingConstants.ATTEMPTS_PER_SESSION
+		}
+
+
+## Handles exit button pressed
+func _handle_exit() -> void:
+	AudioManager.play_ui_click()
+	if _is_drill_complete():
+		_apply_rewards()
+	get_tree().change_scene_to_file("res://scenes/dashboard/console_dashboard.tscn")
+
+
+## Builds the XP summary string for drill completion
+func _build_xp_summary() -> String:
+	var total_xp = _calculate_total_xp()
+	var primary_xp = _calculate_primary_stat_xp()
+	var secondary_xp = _calculate_secondary_stat_xp()
+
+	var summary = "[b]Drill Complete![/b]\n\n"
+	summary += "%s: %d / %d (%.0f%%)\n\n" % [
+		_get_success_label(),
+		successes,
+		attempts_taken,
+		(float(successes) / attempts_taken) * 100
+	]
+
+	summary += "[b]XP Earned:[/b]\n"
+	summary += "Base: %d XP (%d attempts × %d)\n" % [
+		TrainingConstants.XP_PER_ATTEMPT * attempts_taken,
+		attempts_taken,
+		TrainingConstants.XP_PER_ATTEMPT
+	]
+	summary += "%s: +%d XP (%d × %d)\n" % [
+		_get_success_label(),
+		_get_xp_per_success() * successes,
+		successes,
+		_get_xp_per_success()
+	]
+
+	var bonus_xp = _calculate_bonus_xp()
+	if bonus_xp > 0:
+		summary += _get_bonus_xp_breakdown()
+
+	if successes >= 10:
+		summary += "Perfect Session: +%d XP\n" % TrainingConstants.XP_PERFECT_SESSION_BONUS
+	elif successes >= 7:
+		summary += "Good Session: +%d XP\n" % TrainingConstants.XP_GOOD_SESSION_BONUS
+
+	summary += "[b]Total: %d XP[/b]\n\n" % total_xp
+	summary += "[b]Stat XP:[/b]\n"
+	summary += "%s: +%d\n" % [_get_primary_stat(), primary_xp]
+	summary += "%s: +%d\n" % [_get_secondary_stat(), secondary_xp]
+
+	return summary
+
+
+## Override to provide bonus XP breakdown string
+func _get_bonus_xp_breakdown() -> String:
+	return ""
+
+
+## Shows session start narration
+func _show_session_start_narration(narration_label: RichTextLabel) -> void:
+	var narrative = NarrativeEngine.generate_dialogue(_get_drill_name(), "session_start", {})
+	narration_label.text = "[i]%s[/i]" % narrative.text
+
+
+## Shows session end narration
+func _show_session_end_narration(narration_label: RichTextLabel) -> void:
+	var context = {"goals": str(successes), "successes": str(successes), "total": str(attempts_taken)}
+	var narrative = NarrativeEngine.generate_dialogue(_get_drill_name(), "session_end", context)
+	narration_label.text = "[i]%s[/i]" % narrative.text
+
+
+## Updates the score display
+func _update_score_display(score_label: Label, counter_label: Label, counter_prefix: String = "Attempt") -> void:
+	score_label.text = "%d / %d" % [successes, TrainingConstants.ATTEMPTS_PER_SESSION]
+	counter_label.text = "%s %d of %d" % [
+		counter_prefix,
+		mini(attempts_taken + 1, TrainingConstants.ATTEMPTS_PER_SESSION),
+		TrainingConstants.ATTEMPTS_PER_SESSION
+	]

--- a/scripts/training/training_drill_base.gd
+++ b/scripts/training/training_drill_base.gd
@@ -254,11 +254,21 @@ func _apply_rewards() -> void:
 	var total_xp = _calculate_total_xp()
 	var primary_xp = _calculate_primary_stat_xp()
 	var secondary_xp = _calculate_secondary_stat_xp()
+	var stamina_before = player.stamina_current
 
 	player.stamina_current = maxi(player.stamina_current - TrainingConstants.STAMINA_COST, 0)
 	player.add_xp(total_xp)
 	player.add_stat_xp(_get_primary_stat(), primary_xp)
 	player.add_stat_xp(_get_secondary_stat(), secondary_xp)
+
+	_apply_training_injuries({
+		"training_type": _get_drill_name(),
+		"training_intensity": 1.0,
+		"attempts": attempts_taken,
+		"accuracy": float(successes) / float(maxi(attempts_taken, 1)),
+		"player_stamina": stamina_before,
+		"stamina_cost": TrainingConstants.STAMINA_COST
+	})
 
 	DesktopManager.advance_time(1)
 
@@ -268,6 +278,35 @@ func _apply_rewards() -> void:
 		"",
 		"training"
 	)
+
+
+func _apply_training_injuries(training_context: Dictionary) -> void:
+	var team = GameManager.current_team
+	var injury_events = InjurySystem.process_training_injuries(team, training_context)
+
+	for injury in injury_events:
+		var player_name = injury.get("player_name", "Player")
+		var description = injury.get("description", "injury")
+		var matches_out = int(injury.get("matches_out", 0))
+		var severity = injury.get("type", "minor")
+		var specific_type = injury.get("injury_type", "")
+		var severity_text = InjurySystem.get_severity_text(severity)
+
+		var match_suffix = "es" if matches_out != 1 else ""
+		var match_out_text = " (%d match%s out)" % [matches_out, match_suffix] if matches_out > 0 else ""
+		var detail = description if specific_type == "" else "%s (%s)" % [description, specific_type]
+
+		DesktopManager.show_notification(
+			"Injury Report",
+			"%s sustained a %s injury: %s%s." % [
+				player_name,
+				severity_text,
+				detail,
+				match_out_text
+			],
+			"",
+			"training"
+		)
 
 
 ## Saves the best score to player training records

--- a/tests/unit/test_career_manager.gd
+++ b/tests/unit/test_career_manager.gd
@@ -1,0 +1,178 @@
+extends GutTest
+## Unit tests for CareerManager reputation system V1
+
+var _snapshot: Dictionary = {}
+
+
+func before_each() -> void:
+	seed(1337)
+	_snapshot = {
+		"match_history": CareerManager.match_history.duplicate(true),
+		"career_stats": CareerManager.career_stats.duplicate(true),
+		"reputation": CareerManager.reputation,
+		"scout_attention": CareerManager.scout_attention.duplicate(true),
+		"media_coverage": CareerManager.media_coverage,
+		"fan_popularity": CareerManager.fan_popularity,
+		"completed_milestones": CareerManager.completed_milestones.duplicate(true),
+		"rivals": CareerManager.rivals.duplicate(true),
+		"reputation_event_log": CareerManager.reputation_event_log.duplicate(true),
+		"last_match_reputation_report": CareerManager.last_match_reputation_report.duplicate(true),
+		"social_rep_day_key": CareerManager.social_rep_day_key,
+		"social_rep_awarded_today": CareerManager.social_rep_awarded_today,
+		"social_rep_actions_today": CareerManager.social_rep_actions_today
+	}
+	CareerManager.reset_for_new_career()
+
+
+func after_each() -> void:
+	CareerManager.match_history.assign(_snapshot.get("match_history", []))
+	CareerManager.career_stats = _snapshot.get("career_stats", {}).duplicate(true)
+	CareerManager.reputation = int(_snapshot.get("reputation", 10))
+	CareerManager.scout_attention = _snapshot.get("scout_attention", {}).duplicate(true)
+	CareerManager.media_coverage = int(_snapshot.get("media_coverage", 0))
+	CareerManager.fan_popularity = int(_snapshot.get("fan_popularity", 0))
+	CareerManager.completed_milestones.assign(_snapshot.get("completed_milestones", []))
+	CareerManager.rivals.assign(_snapshot.get("rivals", []))
+	CareerManager.reputation_event_log.assign(_snapshot.get("reputation_event_log", []))
+	CareerManager.last_match_reputation_report = _snapshot.get("last_match_reputation_report", {}).duplicate(true)
+	CareerManager.social_rep_day_key = str(_snapshot.get("social_rep_day_key", ""))
+	CareerManager.social_rep_awarded_today = int(_snapshot.get("social_rep_awarded_today", 0))
+	CareerManager.social_rep_actions_today = int(_snapshot.get("social_rep_actions_today", 0))
+
+
+func test_reputation_tier_boundaries() -> void:
+	assert_eq(CareerManager.get_reputation_tier(0).get("id", ""), "unknown")
+	assert_eq(CareerManager.get_reputation_tier(14).get("id", ""), "unknown")
+	assert_eq(CareerManager.get_reputation_tier(15).get("id", ""), "prospect")
+	assert_eq(CareerManager.get_reputation_tier(30).get("id", ""), "rising_star")
+	assert_eq(CareerManager.get_reputation_tier(50).get("id", ""), "noted_talent")
+	assert_eq(CareerManager.get_reputation_tier(70).get("id", ""), "national_buzz")
+	assert_eq(CareerManager.get_reputation_tier(85).get("id", ""), "wonderkid")
+
+
+func test_record_match_result_applies_expected_reputation_delta() -> void:
+	CareerManager.reputation = 10
+	CareerManager.completed_milestones = ["first_goal", "first_assist", "first_motm", "ten_goals"]
+
+	var result = {
+		"goals": 2,
+		"assists": 1,
+		"won": true,
+		"lost": false,
+		"draw": false,
+		"man_of_match": true,
+		"clean_sheet": true,
+		"yellow_cards": 2,
+		"red_card": true,
+		"rating": 8.6,
+		"importance": 1.5
+	}
+
+	CareerManager.record_match_result(result)
+
+	# Raw = +8, scaled by 1.5 => +12
+	assert_eq(CareerManager.reputation, 22)
+	assert_eq(int(result.get("reputation_delta", 0)), 12)
+	assert_eq(int(result.get("reputation_before", 0)), 10)
+	assert_eq(int(result.get("reputation_after", 0)), 22)
+	assert_true(result.has("reputation_breakdown"))
+
+
+func test_record_match_result_applies_milestone_bonus() -> void:
+	CareerManager.reputation = 10
+
+	var result = {
+		"goals": 1,
+		"assists": 0,
+		"won": false,
+		"lost": false,
+		"draw": true,
+		"man_of_match": false,
+		"clean_sheet": false,
+		"yellow_cards": 0,
+		"red_card": false,
+		"rating": 6.0,
+		"importance": 1.0
+	}
+
+	CareerManager.record_match_result(result)
+
+	# +2 for goal and +5 for first_goal milestone.
+	assert_eq(CareerManager.reputation, 17)
+	assert_true("first_goal" in CareerManager.completed_milestones)
+	assert_eq(int(result.get("reputation_delta", 0)), 7)
+
+
+func test_social_reputation_diminishing_and_daily_cap() -> void:
+	CareerManager.reputation = 10
+
+	var r1 = CareerManager.apply_social_reputation("player_post")
+	var r2 = CareerManager.apply_social_reputation("player_post")
+	var r3 = CareerManager.apply_social_reputation("player_post")
+	var r4 = CareerManager.apply_social_reputation("player_reply")
+
+	assert_eq(int(r1.get("applied_delta", 0)), 2)
+	assert_eq(int(r2.get("applied_delta", 0)), 1)
+	assert_eq(int(r3.get("applied_delta", 0)), 1)
+	assert_eq(int(r4.get("applied_delta", 0)), 0)
+	assert_eq(CareerManager.reputation, 14)
+
+	var summary = CareerManager.get_reputation_summary()
+	assert_eq(int(summary.get("daily_social_awarded", 0)), 4)
+	assert_eq(int(summary.get("daily_social_cap", 0)), 4)
+
+
+func test_social_like_only_counts_for_eligible_post_types() -> void:
+	CareerManager.reputation = 10
+
+	var denied = CareerManager.apply_social_reputation("like", {"post_type": "npc_reaction", "liked": true})
+	assert_eq(int(denied.get("applied_delta", 0)), 0)
+	assert_eq(CareerManager.reputation, 10)
+
+	var allowed = CareerManager.apply_social_reputation("like", {"post_type": "news_article", "liked": true})
+	assert_eq(int(allowed.get("applied_delta", 0)), 1)
+	assert_eq(CareerManager.reputation, 11)
+
+
+func test_reputation_tier_changed_signal_emits_on_boundary_cross() -> void:
+	CareerManager.reputation = 14
+	CareerManager.social_rep_day_key = ""
+	CareerManager.social_rep_awarded_today = 0
+	CareerManager.social_rep_actions_today = 0
+
+	var captured := {"called": false, "old": "", "new": ""}
+	var callback := func(old_tier: String, new_tier: String) -> void:
+		captured["called"] = true
+		captured["old"] = old_tier
+		captured["new"] = new_tier
+	CareerManager.reputation_tier_changed.connect(callback, CONNECT_ONE_SHOT)
+
+	CareerManager.apply_social_reputation("player_post")
+
+	assert_true(captured.get("called", false))
+	assert_eq(captured.get("old", ""), "unknown")
+	assert_eq(captured.get("new", ""), "prospect")
+
+
+func test_get_last_match_reputation_report_returns_payload() -> void:
+	var result = {
+		"goals": 0,
+		"assists": 0,
+		"won": true,
+		"lost": false,
+		"draw": false,
+		"man_of_match": false,
+		"clean_sheet": false,
+		"yellow_cards": 0,
+		"red_card": false,
+		"rating": 7.0,
+		"importance": 1.0
+	}
+
+	CareerManager.record_match_result(result)
+	var report = CareerManager.get_last_match_reputation_report()
+
+	assert_true(report.has("reputation_before"))
+	assert_true(report.has("reputation_after"))
+	assert_true(report.has("reputation_delta"))
+	assert_true(report.has("reputation_breakdown"))

--- a/tests/unit/test_career_manager_followers.gd
+++ b/tests/unit/test_career_manager_followers.gd
@@ -1,0 +1,159 @@
+extends GutTest
+## Unit tests for CareerManager follower scaling
+
+var _snapshot: Dictionary = {}
+
+
+func before_each() -> void:
+	seed(1234)
+	_snapshot = {
+		"match_history": CareerManager.match_history.duplicate(true),
+		"career_stats": CareerManager.career_stats.duplicate(true),
+		"reputation": CareerManager.reputation,
+		"fan_popularity": CareerManager.fan_popularity,
+		"media_coverage": CareerManager.media_coverage,
+		"scout_attention": CareerManager.scout_attention.duplicate(true),
+		"completed_milestones": CareerManager.completed_milestones.duplicate(true),
+		"rivals": CareerManager.rivals.duplicate(true),
+		"reputation_event_log": CareerManager.reputation_event_log.duplicate(true),
+		"last_match_reputation_report": CareerManager.last_match_reputation_report.duplicate(true),
+		"social_rep_day_key": CareerManager.social_rep_day_key,
+		"social_rep_awarded_today": CareerManager.social_rep_awarded_today,
+		"social_rep_actions_today": CareerManager.social_rep_actions_today
+	}
+	_reset_career_state()
+
+
+func after_each() -> void:
+	CareerManager.match_history.assign(_snapshot.get("match_history", []))
+	CareerManager.career_stats = _snapshot.get("career_stats", {}).duplicate(true)
+	CareerManager.reputation = int(_snapshot.get("reputation", 10))
+	CareerManager.fan_popularity = int(_snapshot.get("fan_popularity", 0))
+	CareerManager.media_coverage = int(_snapshot.get("media_coverage", 0))
+	CareerManager.scout_attention = _snapshot.get("scout_attention", {}).duplicate(true)
+	CareerManager.completed_milestones.assign(_snapshot.get("completed_milestones", []))
+	CareerManager.rivals.assign(_snapshot.get("rivals", []))
+	CareerManager.reputation_event_log.assign(_snapshot.get("reputation_event_log", []))
+	CareerManager.last_match_reputation_report = _snapshot.get("last_match_reputation_report", {}).duplicate(true)
+	CareerManager.social_rep_day_key = str(_snapshot.get("social_rep_day_key", ""))
+	CareerManager.social_rep_awarded_today = int(_snapshot.get("social_rep_awarded_today", 0))
+	CareerManager.social_rep_actions_today = int(_snapshot.get("social_rep_actions_today", 0))
+
+
+func test_low_rep_win_adds_followers_and_emits_delta() -> void:
+	CareerManager.reputation = 10
+	CareerManager.fan_popularity = 0
+
+	var payload = {"called": false, "new_total": 0, "delta": 0, "outcome": ""}
+	var callback := func(new_total: int, delta: int, outcome: String) -> void:
+		payload["called"] = true
+		payload["new_total"] = new_total
+		payload["delta"] = delta
+		payload["outcome"] = outcome
+	CareerManager.fan_popularity_changed.connect(callback, CONNECT_ONE_SHOT)
+
+	var result = _make_result(true, false, false, 1.0, 2, 1)
+	CareerManager.record_match_result(result)
+
+	assert_eq(CareerManager.fan_popularity, 6, "Win at low rep should add 6 followers")
+	assert_true(payload.get("called", false), "Follower signal should be emitted")
+	assert_eq(payload.get("delta", 0), 6, "Signal delta should be +6")
+	assert_eq(payload.get("new_total", 0), 6, "Signal total should be 6")
+	assert_eq(payload.get("outcome", ""), "win", "Signal should mark outcome as win")
+
+
+func test_high_rep_high_importance_win_scales_to_thirty_three() -> void:
+	CareerManager.reputation = 65
+	CareerManager.fan_popularity = 0
+
+	var result = _make_result(true, false, false, 1.5, 3, 0)
+	CareerManager.record_match_result(result)
+
+	assert_eq(CareerManager.fan_popularity, 33, "Win at rep 65 with 1.5x importance should add 33")
+	assert_eq(result.get("followers_delta", 0), 33)
+	assert_eq(result.get("followers_total", 0), 33)
+
+
+func test_draw_does_not_change_followers() -> void:
+	CareerManager.reputation = 50
+	CareerManager.fan_popularity = 12
+
+	var result = _make_result(false, false, true, 2.0, 1, 1)
+	CareerManager.record_match_result(result)
+
+	assert_eq(CareerManager.fan_popularity, 12, "Draw should not change followers")
+	assert_eq(result.get("followers_delta", 999), 0)
+	assert_eq(result.get("followers_total", 0), 12)
+
+
+func test_loss_applies_penalty_at_mid_reputation() -> void:
+	CareerManager.reputation = 45
+	CareerManager.fan_popularity = 20
+
+	var result = _make_result(false, true, false, 1.0, 0, 1)
+	CareerManager.record_match_result(result)
+
+	assert_eq(CareerManager.fan_popularity, 17, "Loss at rep 45 should subtract 3 followers")
+	assert_eq(result.get("followers_delta", 0), -3)
+	assert_eq(result.get("followers_total", 0), 17)
+
+
+func test_loss_at_zero_followers_is_floored() -> void:
+	CareerManager.reputation = 45
+	CareerManager.fan_popularity = 0
+
+	var result = _make_result(false, true, false, 1.0, 0, 2)
+	CareerManager.record_match_result(result)
+
+	assert_eq(CareerManager.fan_popularity, 0, "Followers should not drop below zero")
+	assert_eq(result.get("followers_delta", 999), 0, "Applied delta should be zero after floor")
+	assert_eq(result.get("followers_total", -1), 0)
+
+
+func test_match_result_contains_follower_metadata_keys() -> void:
+	CareerManager.reputation = 10
+	CareerManager.fan_popularity = 0
+
+	var result = _make_result(true, false, false, 1.0, 1, 0)
+	CareerManager.record_match_result(result)
+
+	assert_true(result.has("followers_delta"), "Result should include followers_delta")
+	assert_true(result.has("followers_total"), "Result should include followers_total")
+
+
+func _make_result(won: bool, lost: bool, draw: bool, importance: float, player_score: int, opponent_score: int) -> Dictionary:
+	return {
+		"won": won,
+		"lost": lost,
+		"draw": draw,
+		"importance": importance,
+		"player_score": player_score,
+		"opponent_score": opponent_score,
+		"goals": 0,
+		"assists": 0,
+		"man_of_match": false
+	}
+
+
+func _reset_career_state() -> void:
+	CareerManager.match_history.clear()
+	CareerManager.career_stats = {
+		"matches_played": 0,
+		"goals": 0,
+		"assists": 0,
+		"clean_sheets": 0,
+		"man_of_match_awards": 0,
+		"trophies": [],
+		"current_season": 1
+	}
+	CareerManager.reputation = 10
+	CareerManager.fan_popularity = 0
+	CareerManager.media_coverage = 0
+	CareerManager.scout_attention = {}
+	CareerManager.completed_milestones.clear()
+	CareerManager.rivals.clear()
+	CareerManager.reputation_event_log.clear()
+	CareerManager.last_match_reputation_report = {}
+	CareerManager.social_rep_day_key = ""
+	CareerManager.social_rep_awarded_today = 0
+	CareerManager.social_rep_actions_today = 0

--- a/tests/unit/test_career_manager_social.gd
+++ b/tests/unit/test_career_manager_social.gd
@@ -1,24 +1,35 @@
 extends GutTest
-## Unit tests for CareerManager social reputation API
+## Unit tests for CareerManager social reputation compatibility API
 
-var _original_reputation: int = 0
+var _snapshot: Dictionary = {}
 
 
 func before_each() -> void:
-	_original_reputation = CareerManager.reputation
+	_snapshot = {
+		"reputation": CareerManager.reputation,
+		"social_rep_day_key": CareerManager.social_rep_day_key,
+		"social_rep_awarded_today": CareerManager.social_rep_awarded_today,
+		"social_rep_actions_today": CareerManager.social_rep_actions_today
+	}
+	CareerManager.reputation = 25
+	CareerManager.social_rep_day_key = ""
+	CareerManager.social_rep_awarded_today = 0
+	CareerManager.social_rep_actions_today = 0
 
 
 func after_each() -> void:
-	CareerManager.reputation = _original_reputation
+	CareerManager.reputation = int(_snapshot.get("reputation", 10))
+	CareerManager.social_rep_day_key = str(_snapshot.get("social_rep_day_key", ""))
+	CareerManager.social_rep_awarded_today = int(_snapshot.get("social_rep_awarded_today", 0))
+	CareerManager.social_rep_actions_today = int(_snapshot.get("social_rep_actions_today", 0))
 
 
 func test_apply_social_reputation_delta_increases_reputation() -> void:
-	CareerManager.reputation = 25
-	CareerManager.apply_social_reputation_delta(2, "v2_thread_engagement")
+	CareerManager.apply_social_reputation_delta(2, "legacy_test")
 	assert_eq(CareerManager.reputation, 27)
 
 
-func test_apply_social_reputation_delta_zero_no_change() -> void:
-	CareerManager.reputation = 25
-	CareerManager.apply_social_reputation_delta(0, "noop")
-	assert_eq(CareerManager.reputation, 25)
+func test_apply_social_reputation_like_uses_new_api() -> void:
+	var result = CareerManager.apply_social_reputation("like", {"post_type": "news_article", "liked": true})
+	assert_eq(int(result.get("applied_delta", 0)), 1)
+	assert_eq(CareerManager.reputation, 26)

--- a/tests/unit/test_career_manager_social.gd
+++ b/tests/unit/test_career_manager_social.gd
@@ -1,0 +1,24 @@
+extends GutTest
+## Unit tests for CareerManager social reputation API
+
+var _original_reputation: int = 0
+
+
+func before_each() -> void:
+	_original_reputation = CareerManager.reputation
+
+
+func after_each() -> void:
+	CareerManager.reputation = _original_reputation
+
+
+func test_apply_social_reputation_delta_increases_reputation() -> void:
+	CareerManager.reputation = 25
+	CareerManager.apply_social_reputation_delta(2, "v2_thread_engagement")
+	assert_eq(CareerManager.reputation, 27)
+
+
+func test_apply_social_reputation_delta_zero_no_change() -> void:
+	CareerManager.reputation = 25
+	CareerManager.apply_social_reputation_delta(0, "noop")
+	assert_eq(CareerManager.reputation, 25)

--- a/tests/unit/test_match_controller_goals.gd
+++ b/tests/unit/test_match_controller_goals.gd
@@ -1,0 +1,150 @@
+extends GutTest
+## Unit tests for MatchController goal/assist attribution
+
+
+var controller: MatchController
+
+
+func before_each() -> void:
+	controller = MatchController.new()
+	controller.match_data = MatchData.new()
+	# Wire up minimal teams so goal events can record team info
+	controller.match_data.home_team = _make_team("home_team", "Home FC")
+	controller.match_data.away_team = _make_team("away_team", "Away FC")
+	controller.match_data.is_home = true
+	add_child(controller)
+
+
+func after_each() -> void:
+	controller.queue_free()
+
+
+# =============================================================================
+# Through-ball last_passer tracking (Bug 1)
+# =============================================================================
+
+func test_through_ball_sets_last_passer() -> void:
+	# Verify _execute_through_ball sets last_passer on success.
+	# We can't easily call _execute_through_ball without full ActionResolver
+	# wiring, so we test the observable effect: when last_passer is set before
+	# a goal, the assist is attributed. This test confirms the plumbing works
+	# by simulating the state that _execute_through_ball now produces.
+	var passer = _make_unit("passer_1", "Passer", true, true)
+	var scorer = _make_unit("scorer_1", "Scorer", false, true)
+
+	controller.last_passer = passer
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)  # Home team scores
+
+	assert_eq(controller.home_goal_events.size(), 1, "Should have one home goal event")
+	var event = controller.home_goal_events[0]
+	assert_eq(event.get("assister_id", ""), "passer_1", "Through-ball passer should get assist")
+	assert_eq(event.get("assister_name", ""), "Passer", "Assister name should be recorded")
+
+
+func test_regular_pass_sets_last_passer() -> void:
+	# Baseline: regular pass → assist attribution works the same way
+	var passer = _make_unit("passer_2", "Midfielder", true, true)
+	var scorer = _make_unit("scorer_2", "Striker", false, true)
+
+	controller.last_passer = passer
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)
+
+	var event = controller.home_goal_events[0]
+	assert_eq(event.get("assister_id", ""), "passer_2")
+
+
+# =============================================================================
+# Player assist recording in match_data (Bug 2)
+# =============================================================================
+
+func test_goal_with_player_assist_records_in_match_data() -> void:
+	var passer = _make_unit("passer_3", "Player Passer", true, true)
+	var scorer = _make_unit("scorer_3", "Teammate", false, true)
+
+	controller.last_passer = passer
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)
+
+	assert_eq(controller.match_data.player_stats.assists, 1,
+		"Player assist should be recorded in match_data")
+
+
+func test_goal_with_npc_assist_does_not_record_player_assist() -> void:
+	var npc_passer = _make_unit("npc_1", "NPC Passer", false, true)  # Not player-controlled
+	var scorer = _make_unit("scorer_4", "Striker", false, true)
+
+	controller.last_passer = npc_passer
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)
+
+	assert_eq(controller.match_data.player_stats.assists, 0,
+		"NPC assist should NOT increment player assists in match_data")
+	# But the goal event should still have the assist attribution
+	var event = controller.home_goal_events[0]
+	assert_eq(event.get("assister_id", ""), "npc_1",
+		"NPC assister should still appear in goal event for season stats")
+
+
+func test_goal_without_assist_records_zero_assists() -> void:
+	var scorer = _make_unit("scorer_5", "Solo Scorer", true, true)
+
+	controller.last_passer = null
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)
+
+	assert_eq(controller.match_data.player_stats.assists, 0,
+		"No assist when no last_passer")
+	var event = controller.home_goal_events[0]
+	assert_false(event.has("assister_id"), "Goal event should have no assister")
+
+
+func test_player_assist_affects_match_rating() -> void:
+	var passer = _make_unit("passer_4", "Playmaker", true, true)
+	var scorer = _make_unit("scorer_6", "Striker", false, true)
+
+	# Record an assist via goal scoring
+	controller.last_passer = passer
+	controller.last_shooter = scorer
+	controller._on_goal_scored(false)
+
+	# Calculate rating — base is 6.0, +0.5 per assist, +0.5 for winning
+	var rating = controller.match_data.calculate_match_rating()
+	# With 1 assist (0.5) and winning (0.5), rating should be 7.0
+	assert_almost_eq(rating, 7.0, 0.01,
+		"Rating should include +0.5 for the assist")
+
+
+func test_away_goal_records_in_away_events() -> void:
+	var scorer = _make_unit("away_scorer", "Away Striker", false, false)  # Away team
+
+	controller.last_passer = null
+	controller.last_shooter = scorer
+	controller._on_goal_scored(true)  # Ball entered home goal → away scored
+
+	assert_eq(controller.away_goal_events.size(), 1, "Should record in away events")
+	assert_eq(controller.home_goal_events.size(), 0, "Should not record in home events")
+	var event = controller.away_goal_events[0]
+	assert_eq(event.get("team_id", ""), "away_team")
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+func _make_unit(id: String, uname: String, is_player: bool, is_home: bool) -> PlayerUnit:
+	var unit = PlayerUnit.new()
+	unit.unit_id = id
+	unit.unit_name = uname
+	unit.is_player_controlled = is_player
+	unit.is_home_team = is_home
+	add_child(unit)
+	return unit
+
+
+func _make_team(id: String, tname: String) -> TeamData:
+	var team = TeamData.new()
+	team.id = id
+	team.name = tname
+	return team

--- a/tests/unit/test_save_manager.gd
+++ b/tests/unit/test_save_manager.gd
@@ -1,0 +1,106 @@
+extends GutTest
+## Unit tests for SaveManager career schema compatibility
+
+var _snapshot: Dictionary = {}
+
+
+func before_each() -> void:
+	_snapshot = {
+		"match_history": CareerManager.match_history.duplicate(true),
+		"career_stats": CareerManager.career_stats.duplicate(true),
+		"reputation": CareerManager.reputation,
+		"media_coverage": CareerManager.media_coverage,
+		"fan_popularity": CareerManager.fan_popularity,
+		"scout_attention": CareerManager.scout_attention.duplicate(true),
+		"reputation_event_log": CareerManager.reputation_event_log.duplicate(true),
+		"last_match_reputation_report": CareerManager.last_match_reputation_report.duplicate(true),
+		"social_rep_day_key": CareerManager.social_rep_day_key,
+		"social_rep_awarded_today": CareerManager.social_rep_awarded_today,
+		"social_rep_actions_today": CareerManager.social_rep_actions_today,
+		"completed_milestones": CareerManager.completed_milestones.duplicate(true),
+		"rivals": CareerManager.rivals.duplicate(true),
+		"phase": GameManager.current_career_phase,
+		"prefecture": GameManager.current_prefecture
+	}
+
+
+func after_each() -> void:
+	CareerManager.match_history.assign(_snapshot.get("match_history", []))
+	CareerManager.career_stats = _snapshot.get("career_stats", {}).duplicate(true)
+	CareerManager.reputation = int(_snapshot.get("reputation", 10))
+	CareerManager.media_coverage = int(_snapshot.get("media_coverage", 0))
+	CareerManager.fan_popularity = int(_snapshot.get("fan_popularity", 0))
+	CareerManager.scout_attention = _snapshot.get("scout_attention", {}).duplicate(true)
+	CareerManager.reputation_event_log.assign(_snapshot.get("reputation_event_log", []))
+	CareerManager.last_match_reputation_report = _snapshot.get("last_match_reputation_report", {}).duplicate(true)
+	CareerManager.social_rep_day_key = str(_snapshot.get("social_rep_day_key", ""))
+	CareerManager.social_rep_awarded_today = int(_snapshot.get("social_rep_awarded_today", 0))
+	CareerManager.social_rep_actions_today = int(_snapshot.get("social_rep_actions_today", 0))
+	CareerManager.completed_milestones.assign(_snapshot.get("completed_milestones", []))
+	CareerManager.rivals.assign(_snapshot.get("rivals", []))
+	GameManager.current_career_phase = int(_snapshot.get("phase", 0))
+	GameManager.current_prefecture = str(_snapshot.get("prefecture", "Kanagawa"))
+
+
+func test_serialize_career_includes_reputation_schema_fields() -> void:
+	CareerManager.media_coverage = 31
+	CareerManager.fan_popularity = 44
+	CareerManager.reputation_event_log = [{"source": "test", "applied_delta": 2}]
+	CareerManager.last_match_reputation_report = {"reputation_delta": 5}
+	CareerManager.social_rep_day_key = "2024-04-02"
+	CareerManager.social_rep_awarded_today = 3
+	CareerManager.social_rep_actions_today = 4
+
+	var data = SaveManager._serialize_career()
+
+	assert_true(data.has("media_coverage"))
+	assert_true(data.has("fan_popularity"))
+	assert_true(data.has("reputation_event_log"))
+	assert_true(data.has("last_match_reputation_report"))
+	assert_true(data.has("social_rep_day_key"))
+	assert_true(data.has("social_rep_awarded_today"))
+	assert_true(data.has("social_rep_actions_today"))
+	assert_eq(int(data.get("media_coverage", 0)), 31)
+	assert_eq(int(data.get("fan_popularity", 0)), 44)
+
+
+func test_apply_save_data_old_save_defaults_new_career_fields() -> void:
+	CareerManager.media_coverage = 99
+	CareerManager.reputation_event_log = [{"source": "old"}]
+	CareerManager.last_match_reputation_report = {"reputation_delta": 9}
+	CareerManager.social_rep_day_key = "stale"
+	CareerManager.social_rep_awarded_today = 9
+	CareerManager.social_rep_actions_today = 9
+
+	var old_style_save = {
+		"version": 1,
+		"career_phase": 0,
+		"player": {},
+		"career": {
+			"match_history": [],
+			"career_stats": {
+				"matches_played": 1,
+				"goals": 0,
+				"assists": 0,
+				"clean_sheets": 0,
+				"man_of_match_awards": 0,
+				"trophies": [],
+				"current_season": 1
+			},
+			"reputation": 18,
+			"scout_attention": {},
+			"completed_milestones": [],
+			"rivals": []
+		}
+	}
+
+	SaveManager._apply_save_data(old_style_save)
+
+	assert_eq(CareerManager.reputation, 18)
+	assert_eq(CareerManager.media_coverage, 0, "Missing media_coverage should default to 0")
+	assert_eq(CareerManager.fan_popularity, 0, "Missing fan_popularity should default to 0")
+	assert_eq(CareerManager.reputation_event_log.size(), 0, "Missing event log should default empty")
+	assert_true(CareerManager.last_match_reputation_report.is_empty(), "Missing match report should default empty")
+	assert_eq(CareerManager.social_rep_day_key, "", "Missing day key should default empty")
+	assert_eq(CareerManager.social_rep_awarded_today, 0)
+	assert_eq(CareerManager.social_rep_actions_today, 0)

--- a/tests/unit/test_social_feed_manager.gd
+++ b/tests/unit/test_social_feed_manager.gd
@@ -4,14 +4,34 @@ extends GutTest
 
 func before_each() -> void:
 	SocialFeedManager.feed.clear()
+	SocialFeedManager.feed_v2.clear()
 	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._next_post_id_v2 = 1
 	SocialFeedManager._reply_queue.clear()
+	SocialFeedManager._reply_queue_v2.clear()
+	SocialFeedManager._v2_recent_reply_keys.clear()
+	SocialFeedManager._v2_last_reply_npc_by_thread.clear()
+	SocialFeedManager._v2_first_npc_reply_awarded.clear()
+	SocialFeedManager._v2_thread_engagement_awarded.clear()
+	SocialFeedManager._v2_notification_day_by_post.clear()
+	SocialFeedManager._v2_social_rep_day_key = ""
+	SocialFeedManager._v2_social_rep_awarded_today = 0
 
 
 func after_each() -> void:
 	SocialFeedManager.feed.clear()
+	SocialFeedManager.feed_v2.clear()
 	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._next_post_id_v2 = 1
 	SocialFeedManager._reply_queue.clear()
+	SocialFeedManager._reply_queue_v2.clear()
+	SocialFeedManager._v2_recent_reply_keys.clear()
+	SocialFeedManager._v2_last_reply_npc_by_thread.clear()
+	SocialFeedManager._v2_first_npc_reply_awarded.clear()
+	SocialFeedManager._v2_thread_engagement_awarded.clear()
+	SocialFeedManager._v2_notification_day_by_post.clear()
+	SocialFeedManager._v2_social_rep_day_key = ""
+	SocialFeedManager._v2_social_rep_awarded_today = 0
 
 
 # ─── Post Creation ───────────────────────────────────────────────
@@ -71,6 +91,14 @@ func test_create_player_post() -> void:
 	assert_eq(post.post_type, "player_post")
 	assert_eq(post.author_id, "player")
 	assert_eq(post.content, "We got this team!")
+
+
+func test_v2_post_creation_does_not_change_v1_feed() -> void:
+	SocialFeedManager.create_player_post("V1 post")
+	SocialFeedManager.create_player_post_v2("V2 post")
+
+	assert_eq(SocialFeedManager.feed.size(), 1, "V1 feed should remain unchanged by V2 posts")
+	assert_eq(SocialFeedManager.feed_v2.size(), 1, "V2 feed should receive V2 post")
 
 
 func test_post_default_values() -> void:

--- a/tests/unit/test_social_feed_manager.gd
+++ b/tests/unit/test_social_feed_manager.gd
@@ -1,0 +1,411 @@
+extends GutTest
+## Unit tests for SocialFeedManager
+
+
+func before_each() -> void:
+	SocialFeedManager.feed.clear()
+	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._reply_queue.clear()
+
+
+func after_each() -> void:
+	SocialFeedManager.feed.clear()
+	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._reply_queue.clear()
+
+
+# ─── Post Creation ───────────────────────────────────────────────
+
+func test_create_post_adds_to_feed() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_001", "Takumi", "teammate",
+		"Great game today!"
+	)
+
+	assert_eq(SocialFeedManager.feed.size(), 1, "Feed should have 1 post")
+	assert_eq(post.post_id, "post_1", "First post should have id post_1")
+	assert_eq(post.content, "Great game today!")
+	assert_eq(post.author_name, "Takumi")
+	assert_eq(post.post_type, "npc_reaction")
+
+
+func test_create_post_increments_id() -> void:
+	SocialFeedManager.create_post("npc_reaction", "npc_001", "A", "teammate", "First")
+	SocialFeedManager.create_post("npc_reaction", "npc_002", "B", "teammate", "Second")
+
+	assert_eq(SocialFeedManager.feed[0].post_id, "post_2", "Newest should be first")
+	assert_eq(SocialFeedManager.feed[1].post_id, "post_1", "Oldest should be second")
+
+
+func test_feed_ordering_newest_first() -> void:
+	SocialFeedManager.create_post("npc_reaction", "a", "A", "teammate", "First")
+	SocialFeedManager.create_post("npc_reaction", "b", "B", "teammate", "Second")
+	SocialFeedManager.create_post("npc_reaction", "c", "C", "teammate", "Third")
+
+	assert_eq(SocialFeedManager.feed[0].content, "Third")
+	assert_eq(SocialFeedManager.feed[1].content, "Second")
+	assert_eq(SocialFeedManager.feed[2].content, "First")
+
+
+func test_feed_cap_at_max_size() -> void:
+	for i in range(SocialFeedManager.MAX_FEED_SIZE + 10):
+		SocialFeedManager.create_post("npc_reaction", "npc", "NPC", "teammate", "Post %d" % i)
+
+	assert_eq(SocialFeedManager.feed.size(), SocialFeedManager.MAX_FEED_SIZE,
+		"Feed should be capped at MAX_FEED_SIZE")
+
+
+func test_create_npc_post() -> void:
+	# Create a post using the NPC helper
+	var post = SocialFeedManager.create_npc_post("npc_test", "Hello!", "match_win", "happy")
+
+	assert_eq(post.post_type, "npc_reaction")
+	assert_eq(post.content, "Hello!")
+	assert_eq(post.event_type, "match_win")
+	assert_eq(post.mood, "happy")
+
+
+func test_create_player_post() -> void:
+	var post = SocialFeedManager.create_player_post("We got this team!")
+
+	assert_eq(post.post_type, "player_post")
+	assert_eq(post.author_id, "player")
+	assert_eq(post.content, "We got this team!")
+
+
+func test_post_default_values() -> void:
+	var post = SocialFeedManager.create_post(
+		"news_article", "news", "FanZone", "news", "Breaking news"
+	)
+
+	assert_eq(post.player_liked, false, "Should not be liked by default")
+	assert_eq(post.replies.size(), 0, "Should have no replies by default")
+	assert_true(post.has("timestamp"), "Should have timestamp")
+	assert_true(post.has("date_string"), "Should have date string")
+	assert_true(post.has("author_handle"), "Should have author handle")
+
+
+# ─── Reply Threading ─────────────────────────────────────────────
+
+func test_add_reply_to_post() -> void:
+	var post = SocialFeedManager.create_post(
+		"player_post", "player", "You", "player", "Let's go!"
+	)
+
+	var reply = SocialFeedManager.add_reply(
+		post.post_id, "npc_001", "Takumi", "teammate", "Yeah!"
+	)
+
+	assert_eq(post.replies.size(), 1, "Post should have 1 reply")
+	assert_eq(reply.content, "Yeah!")
+	assert_eq(reply.author_name, "Takumi")
+	assert_eq(reply.post_type, "reply")
+
+
+func test_add_multiple_replies() -> void:
+	var post = SocialFeedManager.create_post(
+		"player_post", "player", "You", "player", "Let's go!"
+	)
+
+	SocialFeedManager.add_reply(post.post_id, "npc_001", "A", "teammate", "Reply 1")
+	SocialFeedManager.add_reply(post.post_id, "npc_002", "B", "teammate", "Reply 2")
+	SocialFeedManager.add_reply(post.post_id, "npc_003", "C", "teammate", "Reply 3")
+
+	assert_eq(post.replies.size(), 3, "Post should have 3 replies")
+	assert_eq(post.replies[0].content, "Reply 1")
+	assert_eq(post.replies[2].content, "Reply 3")
+
+
+func test_add_reply_to_nonexistent_post() -> void:
+	var reply = SocialFeedManager.add_reply(
+		"nonexistent", "npc_001", "A", "teammate", "Hello"
+	)
+
+	# Should return reply dict but not crash
+	assert_eq(reply.content, "Hello")
+
+
+func test_add_player_reply() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_001", "Takumi", "teammate", "Great day!"
+	)
+
+	var reply = SocialFeedManager.add_player_reply(post.post_id, "Thanks!")
+
+	assert_eq(post.replies.size(), 1)
+	assert_eq(reply.author_id, "player")
+	assert_eq(reply.content, "Thanks!")
+
+
+func test_reply_cap() -> void:
+	var post = SocialFeedManager.create_post(
+		"player_post", "player", "You", "player", "Test"
+	)
+
+	for i in range(SocialFeedManager.MAX_REPLIES_PER_POST + 5):
+		SocialFeedManager.add_reply(post.post_id, "npc", "NPC", "teammate", "Reply %d" % i)
+
+	assert_eq(post.replies.size(), SocialFeedManager.MAX_REPLIES_PER_POST,
+		"Replies should be capped")
+
+
+# ─── Like System ─────────────────────────────────────────────────
+
+func test_toggle_like_on() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_001", "A", "teammate", "Hi",
+		{"likes": 10}
+	)
+
+	SocialFeedManager.toggle_like(post.post_id)
+
+	assert_eq(post.player_liked, true, "Should be liked after toggle")
+	assert_eq(post.likes, 11, "Likes should increment")
+
+
+func test_toggle_like_off() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_001", "A", "teammate", "Hi",
+		{"likes": 10}
+	)
+
+	SocialFeedManager.toggle_like(post.post_id)
+	SocialFeedManager.toggle_like(post.post_id)
+
+	assert_eq(post.player_liked, false, "Should be unliked after double toggle")
+	assert_eq(post.likes, 10, "Likes should return to original")
+
+
+func test_toggle_like_nonexistent_post() -> void:
+	# Should not crash
+	SocialFeedManager.toggle_like("nonexistent")
+	assert_true(true, "Should not crash on nonexistent post")
+
+
+# ─── Feed Filtering ──────────────────────────────────────────────
+
+func test_filter_all() -> void:
+	SocialFeedManager.create_post("npc_reaction", "npc", "A", "teammate", "NPC post")
+	SocialFeedManager.create_post("news_article", "news", "News", "news", "News post")
+	SocialFeedManager.create_post("player_post", "player", "You", "player", "My post")
+
+	var all_posts = SocialFeedManager.get_feed("all")
+	assert_eq(all_posts.size(), 3, "All filter should return everything")
+
+
+func test_filter_npc() -> void:
+	SocialFeedManager.create_post("npc_reaction", "npc", "A", "teammate", "NPC post")
+	SocialFeedManager.create_post("news_article", "news", "News", "news", "News post")
+	SocialFeedManager.create_post("player_post", "player", "You", "player", "My post")
+
+	var npc_posts = SocialFeedManager.get_feed("npc")
+	assert_eq(npc_posts.size(), 1, "NPC filter should return 1 post")
+	assert_eq(npc_posts[0].post_type, "npc_reaction")
+
+
+func test_filter_news() -> void:
+	SocialFeedManager.create_post("npc_reaction", "npc", "A", "teammate", "NPC post")
+	SocialFeedManager.create_post("news_article", "news", "News", "news", "News post")
+	SocialFeedManager.create_post("match_summary", "sys", "Match", "system", "Match")
+	SocialFeedManager.create_post("season_update", "sys", "Season", "system", "Season")
+	SocialFeedManager.create_post("injury_report", "sys", "Injury", "system", "Injury")
+
+	var news_posts = SocialFeedManager.get_feed("news")
+	assert_eq(news_posts.size(), 4, "News filter should include news, match, season, injury")
+
+
+func test_filter_my_posts() -> void:
+	SocialFeedManager.create_post("npc_reaction", "npc", "A", "teammate", "NPC post")
+	SocialFeedManager.create_post("player_post", "player", "You", "player", "My post 1")
+	SocialFeedManager.create_post("player_post", "player", "You", "player", "My post 2")
+
+	var my_posts = SocialFeedManager.get_feed("my_posts")
+	assert_eq(my_posts.size(), 2, "My posts filter should return 2 posts")
+
+
+# ─── Post Lookup ─────────────────────────────────────────────────
+
+func test_get_post_by_id() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc", "A", "teammate", "Find me"
+	)
+
+	var found = SocialFeedManager.get_post_by_id(post.post_id)
+	assert_eq(found.content, "Find me")
+
+
+func test_get_post_by_id_not_found() -> void:
+	var found = SocialFeedManager.get_post_by_id("nonexistent")
+	assert_true(found.is_empty(), "Should return empty dict for missing post")
+
+
+# ─── Handle Generation ───────────────────────────────────────────
+
+func test_handle_generation_two_names() -> void:
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc", "Takumi Yamada", "teammate", "Test"
+	)
+	assert_eq(post.author_handle, "@t_yamada")
+
+
+func test_handle_generation_player() -> void:
+	var post = SocialFeedManager.create_post(
+		"player_post", "player", "You", "player", "Test"
+	)
+	assert_eq(post.author_handle, "@you")
+
+
+func test_handle_generation_news() -> void:
+	var post = SocialFeedManager.create_post(
+		"news_article", "news", "FanZone News", "news", "Test"
+	)
+	assert_eq(post.author_handle, "@fanzone")
+
+
+# ─── NPC Text Generation ────────────────────────────────────────
+
+func test_generate_npc_text_returns_string() -> void:
+	var text = SocialFeedManager._generate_npc_text("nonexistent_npc", "match_win")
+	assert_true(text is String, "Should return a string")
+	assert_true(text.length() > 0, "Should not be empty")
+
+
+func test_map_traits_to_personality() -> void:
+	var traits_passionate: Array[String] = ["emotional", "inspiring"]
+	assert_eq(SocialFeedManager._map_traits_to_personality(traits_passionate), "passionate")
+
+	var traits_leader: Array[String] = ["commanding", "protective"]
+	assert_eq(SocialFeedManager._map_traits_to_personality(traits_leader), "leader")
+
+	var traits_calm: Array[String] = ["composed", "analytical"]
+	assert_eq(SocialFeedManager._map_traits_to_personality(traits_calm), "calm")
+
+	var traits_unknown: Array[String] = ["mysterious", "enigmatic"]
+	assert_eq(SocialFeedManager._map_traits_to_personality(traits_unknown), "reliable",
+		"Unknown traits should fallback to reliable")
+
+
+# ─── Welcome Post ────────────────────────────────────────────────
+
+func test_ensure_welcome_post_on_empty_feed() -> void:
+	SocialFeedManager.ensure_welcome_post()
+
+	assert_eq(SocialFeedManager.feed.size(), 1, "Should add welcome post")
+	assert_eq(SocialFeedManager.feed[0].post_type, "news_article")
+	assert_true(SocialFeedManager.feed[0].content.contains("New Star"))
+
+
+func test_ensure_welcome_post_not_duplicated() -> void:
+	SocialFeedManager.ensure_welcome_post()
+	SocialFeedManager.ensure_welcome_post()
+
+	assert_eq(SocialFeedManager.feed.size(), 1, "Should not duplicate welcome post")
+
+
+# ─── Serialization ───────────────────────────────────────────────
+
+func test_serialization_round_trip() -> void:
+	# Create some posts
+	SocialFeedManager.create_post("npc_reaction", "npc_001", "Takumi", "teammate", "Hello!")
+	var post = SocialFeedManager.create_post("player_post", "player", "You", "player", "Testing")
+	SocialFeedManager.add_reply(post.post_id, "npc_002", "Ren", "teammate", "Nice post!")
+	SocialFeedManager.toggle_like(post.post_id)
+
+	# Serialize
+	var data = SocialFeedManager.to_dict()
+
+	# Clear and restore
+	SocialFeedManager.feed.clear()
+	SocialFeedManager._next_post_id = 1
+	assert_eq(SocialFeedManager.feed.size(), 0)
+
+	SocialFeedManager.from_dict(data)
+
+	# Verify restoration
+	assert_eq(SocialFeedManager.feed.size(), 2, "Should restore 2 posts")
+	assert_eq(SocialFeedManager._next_post_id, data.next_post_id, "Should restore post ID counter")
+
+	# Check post content preserved
+	var restored_post = SocialFeedManager.get_post_by_id(post.post_id)
+	assert_eq(restored_post.content, "Testing")
+	assert_eq(restored_post.player_liked, true, "Like state should be preserved")
+	assert_eq(restored_post.replies.size(), 1, "Replies should be preserved")
+	assert_eq(restored_post.replies[0].content, "Nice post!")
+
+
+func test_serialization_empty_feed() -> void:
+	var data = SocialFeedManager.to_dict()
+	assert_eq(data.feed.size(), 0)
+	assert_eq(data.next_post_id, 1)
+
+	SocialFeedManager.from_dict(data)
+	assert_eq(SocialFeedManager.feed.size(), 0)
+
+
+# ─── Match Event ─────────────────────────────────────────────────
+
+func test_on_match_ended_creates_posts() -> void:
+	var result = {
+		"player_team": "Test High",
+		"opponent": "Rival Academy",
+		"home_score": 3,
+		"away_score": 1,
+		"is_home": true
+	}
+
+	SocialFeedManager.on_match_ended(result)
+
+	# Should create at least a match summary and a news article
+	var has_summary = false
+	var has_news = false
+	for post in SocialFeedManager.feed:
+		if post.post_type == "match_summary":
+			has_summary = true
+			assert_true(post.content.contains("3-1"), "Score should be in summary")
+		if post.post_type == "news_article":
+			has_news = true
+
+	assert_true(has_summary, "Should create match summary post")
+	assert_true(has_news, "Should create news article")
+
+
+func test_on_match_ended_loss() -> void:
+	var result = {
+		"player_team": "Test High",
+		"opponent": "Strong School",
+		"home_score": 0,
+		"away_score": 2,
+		"is_home": true
+	}
+
+	SocialFeedManager.on_match_ended(result)
+
+	var summary = null
+	for post in SocialFeedManager.feed:
+		if post.post_type == "match_summary":
+			summary = post
+			break
+
+	assert_not_null(summary, "Should have match summary")
+	assert_eq(summary.mood, "sad", "Loss should have sad mood")
+
+
+func test_on_match_ended_draw() -> void:
+	var result = {
+		"player_team": "Test High",
+		"opponent": "Equal FC",
+		"home_score": 1,
+		"away_score": 1,
+		"is_home": true
+	}
+
+	SocialFeedManager.on_match_ended(result)
+
+	var summary = null
+	for post in SocialFeedManager.feed:
+		if post.post_type == "match_summary":
+			summary = post
+			break
+
+	assert_not_null(summary, "Should have match summary")
+	assert_eq(summary.mood, "neutral", "Draw should have neutral mood")

--- a/tests/unit/test_social_feed_manager.gd
+++ b/tests/unit/test_social_feed_manager.gd
@@ -1,8 +1,21 @@
 extends GutTest
 ## Unit tests for SocialFeedManager
 
+var _original_reputation: int = 10
+var _original_social_day_key: String = ""
+var _original_social_awarded_today: int = 0
+var _original_social_actions_today: int = 0
 
 func before_each() -> void:
+	_original_reputation = CareerManager.reputation
+	_original_social_day_key = CareerManager.social_rep_day_key
+	_original_social_awarded_today = CareerManager.social_rep_awarded_today
+	_original_social_actions_today = CareerManager.social_rep_actions_today
+	CareerManager.reputation = 10
+	CareerManager.social_rep_day_key = ""
+	CareerManager.social_rep_awarded_today = 0
+	CareerManager.social_rep_actions_today = 0
+
 	SocialFeedManager.feed.clear()
 	SocialFeedManager.feed_v2.clear()
 	SocialFeedManager._next_post_id = 1
@@ -19,6 +32,11 @@ func before_each() -> void:
 
 
 func after_each() -> void:
+	CareerManager.reputation = _original_reputation
+	CareerManager.social_rep_day_key = _original_social_day_key
+	CareerManager.social_rep_awarded_today = _original_social_awarded_today
+	CareerManager.social_rep_actions_today = _original_social_actions_today
+
 	SocialFeedManager.feed.clear()
 	SocialFeedManager.feed_v2.clear()
 	SocialFeedManager._next_post_id = 1
@@ -437,3 +455,77 @@ func test_on_match_ended_draw() -> void:
 
 	assert_not_null(summary, "Should have match summary")
 	assert_eq(summary.mood, "neutral", "Draw should have neutral mood")
+
+
+func test_on_match_ended_accepts_runtime_result_shape() -> void:
+	var result = {
+		"player_score": 2,
+		"opponent_score": 1,
+		"opponent_name": "Runtime Opponent"
+	}
+
+	SocialFeedManager.on_match_ended(result)
+
+	var summary = null
+	for post in SocialFeedManager.feed:
+		if post.post_type == "match_summary":
+			summary = post
+			break
+
+	assert_not_null(summary, "Should have match summary")
+	assert_true(summary.content.contains("2-1"), "Runtime schema score should be rendered")
+	assert_eq(summary.mood, "happy")
+
+
+func test_create_player_post_awards_social_reputation() -> void:
+	CareerManager.reputation = 10
+	SocialFeedManager.create_player_post("Social hook test")
+	assert_eq(CareerManager.reputation, 12)
+
+
+func test_add_player_reply_awards_social_reputation() -> void:
+	CareerManager.reputation = 10
+	var post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_001", "Takumi", "teammate", "Reply to me"
+	)
+	SocialFeedManager.add_player_reply(post.post_id, "Sure thing")
+	assert_eq(CareerManager.reputation, 11)
+
+
+func test_toggle_like_social_reputation_only_for_eligible_post_types() -> void:
+	CareerManager.reputation = 10
+	var news_post = SocialFeedManager.create_post(
+		"news_article", "news", "FanZone News", "news", "Headline"
+	)
+	SocialFeedManager.toggle_like(news_post.post_id)
+	assert_eq(CareerManager.reputation, 11)
+
+	var npc_post = SocialFeedManager.create_post(
+		"npc_reaction", "npc_002", "Ren", "teammate", "Hello"
+	)
+	SocialFeedManager.toggle_like(npc_post.post_id)
+	assert_eq(CareerManager.reputation, 11, "NPC likes should not award social reputation")
+
+
+func test_high_reputation_scales_match_summary_and_news_likes() -> void:
+	CareerManager.reputation = 90
+	var result = {
+		"player_score": 3,
+		"opponent_score": 1,
+		"opponent_name": "Scale FC"
+	}
+
+	SocialFeedManager.on_match_ended(result)
+
+	var summary = null
+	var news = null
+	for post in SocialFeedManager.feed:
+		if summary == null and post.post_type == "match_summary":
+			summary = post
+		if news == null and post.post_type == "news_article":
+			news = post
+
+	assert_not_null(summary)
+	assert_not_null(news)
+	assert_true(int(summary.likes) >= 46, "High reputation should raise summary like floor")
+	assert_true(int(news.likes) >= 28, "High reputation should raise news like floor")

--- a/tests/unit/test_social_feed_manager_v2.gd
+++ b/tests/unit/test_social_feed_manager_v2.gd
@@ -3,11 +3,20 @@ extends GutTest
 
 var _original_team: TeamData
 var _original_reputation: int = 0
+var _original_social_day_key: String = ""
+var _original_social_awarded_today: int = 0
+var _original_social_actions_today: int = 0
 
 
 func before_each() -> void:
 	_original_team = GameManager.current_team
 	_original_reputation = CareerManager.reputation
+	_original_social_day_key = CareerManager.social_rep_day_key
+	_original_social_awarded_today = CareerManager.social_rep_awarded_today
+	_original_social_actions_today = CareerManager.social_rep_actions_today
+	CareerManager.social_rep_day_key = ""
+	CareerManager.social_rep_awarded_today = 0
+	CareerManager.social_rep_actions_today = 0
 
 	var test_team = TeamData.new()
 	test_team.name = "Test High"
@@ -34,6 +43,9 @@ func before_each() -> void:
 func after_each() -> void:
 	GameManager.current_team = _original_team
 	CareerManager.reputation = _original_reputation
+	CareerManager.social_rep_day_key = _original_social_day_key
+	CareerManager.social_rep_awarded_today = _original_social_awarded_today
+	CareerManager.social_rep_actions_today = _original_social_actions_today
 
 	SocialFeedManager.feed.clear()
 	SocialFeedManager.feed_v2.clear()
@@ -120,11 +132,12 @@ func test_social_reputation_daily_cap() -> void:
 	SocialFeedManager._v2_social_rep_day_key = SocialFeedManager._get_v2_day_key()
 	SocialFeedManager._v2_social_rep_awarded_today = 0
 
-	assert_true(SocialFeedManager._grant_v2_social_reputation(1, "test_1"))
-	assert_true(SocialFeedManager._grant_v2_social_reputation(1, "test_2"))
-	assert_false(SocialFeedManager._grant_v2_social_reputation(1, "test_3"))
-	assert_eq(SocialFeedManager._v2_social_rep_awarded_today, 2, "Daily cap should stop further social reputation gains")
-	assert_eq(CareerManager.reputation, 12, "Only two points should apply under the +2/day cap")
+	assert_true(SocialFeedManager._grant_v2_social_reputation(2, "test_1"))
+	assert_true(SocialFeedManager._grant_v2_social_reputation(2, "test_2"))
+	assert_true(SocialFeedManager._grant_v2_social_reputation(2, "test_3"))
+	assert_false(SocialFeedManager._grant_v2_social_reputation(2, "test_4"))
+	assert_eq(SocialFeedManager._v2_social_rep_awarded_today, 4, "Daily cap should stop further social reputation gains")
+	assert_eq(CareerManager.reputation, 14, "Social gains should cap at +4/day")
 
 
 func test_v2_reply_queue_dedupes_same_npc_per_thread_window() -> void:

--- a/tests/unit/test_social_feed_manager_v2.gd
+++ b/tests/unit/test_social_feed_manager_v2.gd
@@ -1,0 +1,163 @@
+extends GutTest
+## Unit tests for SocialFeedManager V2 feed behavior
+
+var _original_team: TeamData
+var _original_reputation: int = 0
+
+
+func before_each() -> void:
+	_original_team = GameManager.current_team
+	_original_reputation = CareerManager.reputation
+
+	var test_team = TeamData.new()
+	test_team.name = "Test High"
+	test_team.players = [
+		{"id": "npc_001", "name": "Takumi"}
+	]
+	GameManager.current_team = test_team
+
+	SocialFeedManager.feed.clear()
+	SocialFeedManager.feed_v2.clear()
+	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._next_post_id_v2 = 1
+	SocialFeedManager._reply_queue.clear()
+	SocialFeedManager._reply_queue_v2.clear()
+	SocialFeedManager._v2_recent_reply_keys.clear()
+	SocialFeedManager._v2_last_reply_npc_by_thread.clear()
+	SocialFeedManager._v2_first_npc_reply_awarded.clear()
+	SocialFeedManager._v2_thread_engagement_awarded.clear()
+	SocialFeedManager._v2_notification_day_by_post.clear()
+	SocialFeedManager._v2_social_rep_day_key = SocialFeedManager._get_v2_day_key()
+	SocialFeedManager._v2_social_rep_awarded_today = 0
+
+
+func after_each() -> void:
+	GameManager.current_team = _original_team
+	CareerManager.reputation = _original_reputation
+
+	SocialFeedManager.feed.clear()
+	SocialFeedManager.feed_v2.clear()
+	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._next_post_id_v2 = 1
+	SocialFeedManager._reply_queue.clear()
+	SocialFeedManager._reply_queue_v2.clear()
+	SocialFeedManager._v2_recent_reply_keys.clear()
+	SocialFeedManager._v2_last_reply_npc_by_thread.clear()
+	SocialFeedManager._v2_first_npc_reply_awarded.clear()
+	SocialFeedManager._v2_thread_engagement_awarded.clear()
+	SocialFeedManager._v2_notification_day_by_post.clear()
+	SocialFeedManager._v2_social_rep_day_key = ""
+	SocialFeedManager._v2_social_rep_awarded_today = 0
+
+
+func test_normalize_match_result_tactical_schema() -> void:
+	var normalized = SocialFeedManager._normalize_match_result_for_feed({
+		"player_score": 2,
+		"opponent_score": 1,
+		"opponent_name": "Rival Academy"
+	})
+
+	assert_eq(normalized.player_score, 2)
+	assert_eq(normalized.opponent_score, 1)
+	assert_eq(normalized.opponent_name, "Rival Academy")
+	assert_eq(normalized.result_type, "win")
+
+
+func test_normalize_match_result_legacy_schema() -> void:
+	var normalized = SocialFeedManager._normalize_match_result_for_feed({
+		"player_team": "Test High",
+		"opponent": "Legacy Opponent",
+		"home_score": 0,
+		"away_score": 3,
+		"is_home": true
+	})
+
+	assert_eq(normalized.player_team_name, "Test High")
+	assert_eq(normalized.opponent_name, "Legacy Opponent")
+	assert_eq(normalized.player_score, 0)
+	assert_eq(normalized.opponent_score, 3)
+	assert_eq(normalized.result_type, "loss")
+
+
+func test_get_feed_v2_latest_is_strict_chronological() -> void:
+	var old_post = SocialFeedManager.create_post_v2(
+		"news_article", "news", "FanZone", "news", "Older",
+		{"likes": 30, "priority": 95}
+	)
+	var new_post = SocialFeedManager.create_post_v2(
+		"player_post", "player", "You", "player", "Newer",
+		{"likes": 1, "priority": 10}
+	)
+
+	old_post.timestamp = Time.get_unix_time_from_system() - (10 * 24 * 3600)
+	new_post.timestamp = Time.get_unix_time_from_system()
+
+	var latest = SocialFeedManager.get_feed_v2("all", "latest")
+	assert_eq(latest[0].post_id, new_post.post_id, "Latest mode should be newest-first")
+
+
+func test_get_feed_v2_top_uses_hybrid_relevance() -> void:
+	var old_high_signal = SocialFeedManager.create_post_v2(
+		"news_article", "news", "FanZone", "news", "Historic post",
+		{"likes": 0, "priority": 95}
+	)
+	var new_low_signal = SocialFeedManager.create_post_v2(
+		"player_post", "player", "You", "player", "Fresh post",
+		{"likes": 1, "priority": 10}
+	)
+
+	old_high_signal.timestamp = Time.get_unix_time_from_system() - (10 * 24 * 3600)
+	old_high_signal.likes = 30
+	new_low_signal.timestamp = Time.get_unix_time_from_system()
+
+	var top = SocialFeedManager.get_feed_v2("all", "top")
+	assert_eq(top[0].post_id, old_high_signal.post_id, "Top mode should allow strong engagement/priority to outrank recency")
+	assert_true(str(top[0].get("ranking_reason", "")) != "", "Top mode should provide ranking reason metadata")
+
+
+func test_social_reputation_daily_cap() -> void:
+	CareerManager.reputation = 10
+	SocialFeedManager._v2_social_rep_day_key = SocialFeedManager._get_v2_day_key()
+	SocialFeedManager._v2_social_rep_awarded_today = 0
+
+	assert_true(SocialFeedManager._grant_v2_social_reputation(1, "test_1"))
+	assert_true(SocialFeedManager._grant_v2_social_reputation(1, "test_2"))
+	assert_false(SocialFeedManager._grant_v2_social_reputation(1, "test_3"))
+	assert_eq(SocialFeedManager._v2_social_rep_awarded_today, 2, "Daily cap should stop further social reputation gains")
+	assert_eq(CareerManager.reputation, 12, "Only two points should apply under the +2/day cap")
+
+
+func test_v2_reply_queue_dedupes_same_npc_per_thread_window() -> void:
+	var post = SocialFeedManager.create_post_v2(
+		"player_post", "player", "You", "player", "Thread starter",
+		{"likes": 0}
+	)
+
+	SocialFeedManager._reply_queue_v2.clear()
+	SocialFeedManager._queue_npc_replies_v2(post.post_id, "player_post")
+	var initial_size = SocialFeedManager._reply_queue_v2.size()
+
+	SocialFeedManager._queue_npc_replies_v2(post.post_id, "player_post")
+	var deduped_size = SocialFeedManager._reply_queue_v2.size()
+
+	assert_eq(initial_size, 1, "Single NPC candidate should queue exactly one reply")
+	assert_eq(deduped_size, 1, "Second queue call within dedupe window should not enqueue duplicate reply")
+
+
+func test_from_dict_bootstraps_v2_when_absent() -> void:
+	SocialFeedManager.create_post("news_article", "news", "FanZone", "news", "Legacy post")
+	var legacy_payload = {
+		"feed": SocialFeedManager.feed.duplicate(true),
+		"next_post_id": SocialFeedManager._next_post_id
+	}
+
+	SocialFeedManager.feed.clear()
+	SocialFeedManager.feed_v2.clear()
+	SocialFeedManager._next_post_id = 1
+	SocialFeedManager._next_post_id_v2 = 1
+
+	SocialFeedManager.from_dict(legacy_payload)
+
+	assert_eq(SocialFeedManager.feed.size(), 1)
+	assert_eq(SocialFeedManager.feed_v2.size(), 1, "V2 feed should bootstrap from V1 data when V2 payload is missing")
+	assert_eq(SocialFeedManager.feed_v2[0].schema_version, SocialFeedManager.V2_SCHEMA_VERSION)


### PR DESCRIPTION
## Summary

This PR prepares the first playable alpha of the **soccer-rpg** career loop, adding tactical substitutions, unit-level initiative turns, a training-driven injury model, and the initial FanZone social dashboard with player reputation.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes to existing systems' public APIs)
- [x] Documentation update (design/implementation reports)

## Changes Made

- Implemented a tactical substitution system with per-side substitution budgets, automatic bench selection, and a new Substitute action in the tactical match UI, backed by `MatchController` helpers and related scene wiring.
- Switched tactical turns to a unit-level initiative queue (with stat-driven initiative, jitter, and player-control bonuses) so actors take turns based on initiative rather than rigid team-phase sequencing.
- Reworked injuries into a training-focused injury system with weighted categories and concrete injury types, plus helpers for rolling, applying, and surfacing training injury events, while deprecating match-level rolls.
- Added the first pass of the FanZone social media dashboard (FanZone V2) and `SocialFeedManager`, wiring post-match hooks so match results can drive social feed events and future narrative content.
- Introduced a player reputation system v1 with reputation values, tiers, and basic UI hooks on the player mini-card and post-match screen.
- Fixed matchday assignment per round and updated season awards tracking to record tactical match goal events for all scorers, not just simulated matches.
- Updated project configuration (autoload for `SocialFeedManager`, debug flag for `fanzone_v2_enabled`) and desktop shell input handling to address the OS click-through issue.
- Added internal design docs for substitutions, unit-level initiative, and season awards, documenting scope, current behavior, and follow-up work.

## Related Issues

- Documents and mitigates the OS click bug in the desktop shell, including a code-level fix to mouse filtering.
- Completes tactical match goal attribution required by the Season Awards feature spec.

## Testing

- [x] Manually tested tactical matches with substitutions, injuries, and initiative ordering in-game.
- [x] Manually verified FanZone V2 panel wiring and navigation from the dashboard.
- [ ] Ran full automated test suite (GUT).
- [ ] Added targeted unit tests for injury distribution and initiative ordering.

## Additional Notes

- Substitution selection is currently automated (lowest-rated outgoing, highest-rated bench incoming) to keep scope contained for this alpha; explicit selection UI is planned as a follow-up.
- Training-only injury rolls are intentionally conservative, with capped probabilities per session and richer text descriptions to support narrative surfacing in FanZone and commentary.
- FanZone V2 and reputation v1 are intentionally minimal and behind a debug flag to allow iteration on content, tuning, and UX without affecting the stable dashboard flow.